### PR TITLE
Public declaration and getIdentities

### DIFF
--- a/contracts/registry/ClaimVerifier.sol
+++ b/contracts/registry/ClaimVerifier.sol
@@ -7,7 +7,7 @@ contract ClaimVerifier{
 
     uint[] issuerIndexes;
     ClaimHolder trustedClaimHolder;
-    TrustedIssuersRegistry issuersRegistry;
+    TrustedIssuersRegistry public issuersRegistry;
 
     event ClaimValid(ClaimHolder _identity, uint256 claimType);
     event ClaimInvalid(ClaimHolder _identity, uint256 claimType);

--- a/contracts/registry/IdentityRegistry.sol
+++ b/contracts/registry/IdentityRegistry.sol
@@ -20,7 +20,7 @@ contract IdentityRegistry is Ownable, ClaimVerifier {
 
     IdentityContract[] public identities;
 
-    ClaimTypesRegistry typesRegistry;
+    ClaimTypesRegistry public typesRegistry;
 
     event identityRegistered(address indexed investorAddress, ClaimHolder indexed identity);
     event identityRemoved(address indexed investorAddress, ClaimHolder indexed identity);

--- a/contracts/registry/IdentityRegistry.sol
+++ b/contracts/registry/IdentityRegistry.sol
@@ -75,6 +75,24 @@ contract IdentityRegistry is Ownable, ClaimVerifier {
         identity[_user] = _identity;
     }
 
+    /**
+    * @notice Get the list of registered identities.
+    *
+    * @return The array of users and the array of their identities (must be destructured).
+    */
+    function getIdentities() public view returns (address[], ClaimHolder[]) {
+        address[] memory users = new address[](identities.length);
+        ClaimHolder[] memory userIdentities = new ClaimHolder[](identities.length);
+
+        for (uint i = 0; i < identities.length; i++) {
+            IdentityContract storage identityContract = identities[i];
+            users[i] = identityContract.user;
+            userIdentities[i] = identityContract.userIdentity;
+        }
+
+        return (users, userIdentities);
+    }
+
 
     /**
     * @notice Updates the country corresponding to a user address.

--- a/contracts/registry/IdentityRegistry.sol
+++ b/contracts/registry/IdentityRegistry.sol
@@ -85,7 +85,7 @@ contract IdentityRegistry is Ownable, ClaimVerifier {
         ClaimHolder[] memory userIdentities = new ClaimHolder[](identities.length);
 
         for (uint i = 0; i < identities.length; i++) {
-            IdentityContract storage identityContract = identities[i];
+            IdentityContract memory identityContract = identities[i];
             users[i] = identityContract.user;
             userIdentities[i] = identityContract.userIdentity;
         }

--- a/contracts/token/TransferManager.sol
+++ b/contracts/token/TransferManager.sol
@@ -17,7 +17,7 @@ contract TransferManager is Ownable, StandardToken {
 
     IdentityRegistry public identityRegistry;
 
-    Compliance compliance;
+    Compliance public compliance;
 
     event identityRegistryAdded(address indexed _identityRegistry);
 

--- a/contracts/token/TransferManager.sol
+++ b/contracts/token/TransferManager.sol
@@ -15,7 +15,7 @@ contract TransferManager is Ownable, StandardToken {
 
     address[] private shareholders;
 
-    IdentityRegistry identityRegistry;
+    IdentityRegistry public identityRegistry;
 
     Compliance compliance;
 


### PR DESCRIPTION
# Missing public declaration and a function to retrieve identities.

I have added the following missing public declarations:
- typesRegistry of IdentityRegistry
- issuersRegistry of ClaimVerifier
- identityRegistry of Token
- compliance of Token

I have added a getIdentities method in IdentityRegistry. It seems I can't return directly the struct array (solidity compiler returns an error:
```
TypeError: This type is only supported in the new experimental ABI encoder. Use "pragma experimental ABIEncoderV2;" to enable the feature.
    function getIdentities() public view returns (IdentityContract[]) {
```
So I used a trick to return the list of user addresses and their identities instead.