### PR TITLE
fix(ERC725): Add missing removeKey signature.

### DIFF
--- a/contracts/identity/ERC725.sol
+++ b/contracts/identity/ERC725.sol
@@ -23,6 +23,7 @@ contract ERC725 {
     function getKeyPurpose(bytes32 _key) public constant returns(uint256 purpose);
     function getKeysByPurpose(uint256 _purpose) public constant returns(bytes32[] keys);
     function addKey(bytes32 _key, uint256 _purpose, uint256 _keyType) public returns (bool success);
+    function removeKey(bytes32 _key) public returns (bool success);
     function execute(address _to, uint256 _value, bytes _data) public payable returns (uint256 executionId);
     function approve(uint256 _id, bool _approve) public returns (bool success);
 }


### PR DESCRIPTION
The ERC725 interface is missing the removeKey signature. This PR adds the missing signature so that the KeyHolder contract can fully be exploited using the ERC725 interface.