### PR TITLE
Decimals on implementation

### DIFF
--- a/contracts/token/IToken.sol
+++ b/contracts/token/IToken.sol
@@ -5,7 +5,7 @@ contract IToken{
 
     string public name;
     string public symbol;
-    uint8 public constant decimals = 0;
+    uint8 public constant decimals;
     string public version;
 
     event UpdatedTokenInformation(string newName, string newSymbol, string newVersion);

--- a/contracts/token/Token.sol
+++ b/contracts/token/Token.sol
@@ -7,7 +7,7 @@ contract Token is IToken, MintableAndBurnable {
     string public name = "TREXDINO";
     string public symbol = "TREX";
     string public version = "1.2";
-    // uint8 public constant decimals = 0;
+    uint8 public constant decimals = 0;
 
     constructor(
         address _identityRegistry,


### PR DESCRIPTION
none of the token specifications should be instantiated at interface level, the value should be set at the implementation level. That's why the decimals should just be declared in the `IToken.sol` contract and instantiated in the `Token.sol` contract.