### PR TITLE
fix(IToken) Remove constant declaration from interface

### DIFF
--- a/contracts/token/IToken.sol
+++ b/contracts/token/IToken.sol
@@ -5,7 +5,7 @@ contract IToken{
 
     string public name;
     string public symbol;
-    uint8 public constant decimals;
+    uint8 public decimals;
     string public version;
 
     event UpdatedTokenInformation(string newName, string newSymbol, string newVersion);


### PR DESCRIPTION
The interface cannot declare constant properties that are not defined.

I have removed the constant declaration from the interface.