### PR TITLE
Update TrustedIssuersRegistry.sol

### DIFF
--- a/contracts/registry/TrustedIssuersRegistry.sol
+++ b/contracts/registry/TrustedIssuersRegistry.sol
@@ -71,6 +71,7 @@ contract TrustedIssuersRegistry is ITrustedIssuersRegistry, Ownable {
                 delete trustedIssuerClaimTopics[index][i];
             }
         }
+        trustedIssuer[address(trustedIssuers[index])] = false;
         delete trustedIssuer[address(trustedIssuers[index])];
         delete trustedIssuerClaimCount[index];
 


### PR DESCRIPTION
temporary fix by setting false on removal
Trusted Issuer is correctly removed from the trustedIssuers mapping but returning true on isTrustedIssuer()