### PR TITLE
🐛(Token) Add decimals as updatable information

### DIFF
--- a/contracts/token/IToken.sol
+++ b/contracts/token/IToken.sol
@@ -8,8 +8,8 @@ contract IToken{
     uint8 public decimals;
     string public version;
 
-    event UpdatedTokenInformation(string newName, string newSymbol, string newVersion);
+    event UpdatedTokenInformation(string newName, string newSymbol, uint8 newDecimals, string newVersion);
 
-    function setTokenInformation(string calldata _name, string calldata _symbol, string calldata _version) external;
+    function setTokenInformation(string calldata _name, string calldata _symbol, uint8 _decimals, string calldata _version) external;
 
 }

--- a/contracts/token/Token.sol
+++ b/contracts/token/Token.sol
@@ -7,7 +7,7 @@ contract Token is IToken, MintableAndBurnable {
     string public name = "TREXDINO";
     string public symbol = "TREX";
     string public version = "1.2";
-    uint8 public constant decimals = 0;
+    uint8 public decimals = 0;
 
     constructor(
         address _identityRegistry,
@@ -20,11 +20,12 @@ contract Token is IToken, MintableAndBurnable {
     /**
     * Owner can update token information here
     */
-    function setTokenInformation(string calldata _name, string calldata _symbol, string calldata _version) external onlyOwner {
+    function setTokenInformation(string calldata _name, string calldata _symbol, uint8 _decimals, string calldata _version) external onlyOwner {
         name = _name;
         symbol = _symbol;
+        decimals = _decimals;
         version = _version;
 
-        emit UpdatedTokenInformation(name, symbol, version);
+        emit UpdatedTokenInformation(name, symbol, decimals, version);
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokeny/trex-solidity",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A fully compliant environment for the issuance and use of tokenized securities.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Decimals were set as constant in the Token Contract.

It is now an updatable information. 

Another possibility would be to add the decimals count in the constructor (because it doesn't make much sense to allow for this info to be updated).