### PR TITLE
Remove duplicate of agent role behavior

### DIFF
--- a/contracts/registry/IdentityRegistry.sol
+++ b/contracts/registry/IdentityRegistry.sol
@@ -10,54 +10,7 @@ import "../roles/AgentRole.sol";
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import "@onchain-id/solidity/contracts/Identity.sol";
 
-contract MultiAgent is Ownable {
-    address private _agent;
-
-    mapping(address => bool) agents;
-
-    event AgentshipTransferred(address indexed previousAgent, address indexed newAgent);
-    event NewAgentAdded(address indexed newAgent);
-    event AgentRemoved(address indexed agent);
-
-
-
-    /**
-     * @dev Returns the address of the current agent.
-     */
-    function agent() public view returns (address) {
-        return _agent;
-    }
-
-    /**
-     * @dev Throws if called by any account other than the agent.
-     */
-    modifier onlyAgent() {
-        require(isAgent(), "Ownable: caller is not the owner");
-        _;
-    }
-
-    /**
-     * @dev Returns true if the caller is the current owner.
-     */
-    function isAgent() public view returns (bool) {
-        return agents[msg.sender];
-        // return msg.sender == _agent;
-    }
-
-    function addAgent(address newAgent) public onlyOwner {
-        require(newAgent != address(0), "Ownable: new Agent is the zero address");
-        agents[newAgent] = true;
-        emit NewAgentAdded(newAgent);
-    }
-
-    function removeAgent(address _agent_) public onlyOwner {
-        require(_agent_ != address(0), "Ownable: new owner is the zero address");
-        delete agents[_agent_];
-        emit AgentRemoved(_agent_);
-    }
-}
-
-contract IdentityRegistry is IIdentityRegistry, MultiAgent {
+contract IdentityRegistry is IIdentityRegistry, AgentRole {
 
     constructor (
         address _trustedIssuersRegistry,

--- a/contracts/token/IToken.sol
+++ b/contracts/token/IToken.sol
@@ -9,9 +9,8 @@ contract IToken{
     string public version;
     address public onchainID;
 
-    event UpdatedTokenInformation(string newName, string newSymbol, string newVersion, uint8 newDecimals, address newOnchainID);
+    event UpdatedTokenInformation(string newName, string newSymbol, uint8 newDecimals, string newVersion, address newOnchainID);
 
-    function setTokenInformation(string calldata _name, string calldata _symbol, uint8 _decimals, string calldata _version, address calldata _onchainID) external;
-
+    function setTokenInformation(string calldata _name, string calldata _symbol, uint8 _decimals, string calldata _version, address _onchainID) external;
 
 }

--- a/contracts/token/Token.sol
+++ b/contracts/token/Token.sol
@@ -21,8 +21,7 @@ contract Token is IToken, MintableAndBurnable {
     /**
     * Owner can update token information here
     */
-
-    function setTokenInformation(string calldata _name, string calldata _symbol, uint8 _decimals, string calldata _version, address calldata _onchainID) external onlyOwner {
+    function setTokenInformation(string calldata _name, string calldata _symbol, uint8 _decimals, string calldata _version, address _onchainID) external onlyOwner {
 
         name = _name;
         symbol = _symbol;


### PR DESCRIPTION
I removed the MultiAgent contract and used the RoleAgent contract instead for the IdentityRegistry contract.

I have also fixed an issue with the parameters of the setTokenInformation method (calldata is not allowed for address type).
Order was wrong in the event for version and decimals.