### PR TITLE
♻ forcedTransfer on partial freeze

### DIFF
--- a/contracts/token/TransferManager.sol
+++ b/contracts/token/TransferManager.sol
@@ -196,9 +196,11 @@ contract TransferManager is Pausable, ERC20 {
 
     /**
     *
-    *  Require that the from address has enough available tokens to
-    *  transfer `value` amount if he has partial freeze on some tokens.
-    *  Require that the `value` should not exceed available balance.
+    *  In case the `from` address has not enough free tokens (unfrozen tokens)
+    *  but has a total balance higher or equal to the `value` amount
+    *  the amount of frozen tokens is reduced in order to have enough free tokens
+    *  to proceed the transfer, in such a case, the remaining balance on the `from`
+    *  account is 100% composed of frozen tokens post-transfer.
     *  Require that the `to` address is a verified address,
     *  If the `to` address is not currently a shareholder then it MUST become one.
     *  If the transfer will reduce `from`'s balance to 0 then that address

--- a/contracts/token/TransferManager.sol
+++ b/contracts/token/TransferManager.sol
@@ -211,7 +211,11 @@ contract TransferManager is Pausable, ERC20 {
     * @return `true` if successful and revert if unsuccessful
     */
     function forcedTransfer(address _from, address _to, uint256 _value) public onlyAgent returns (bool) {
-        require(_value <= balanceOf(_from).sub(frozenTokens[_from]), "Sender Has Insufficient Balance");
+        uint256 freeBalance = balanceOf(_from) - frozenTokens[_from];
+        if (_value > freeBalance) {
+            uint256 tokensToUnfreeze = _value - freeBalance;
+            frozenTokens[_from] -= tokensToUnfreeze;
+        }
         if (identityRegistry.isVerified(_to) && compliance.canTransfer(_from, _to, _value)) {
             updateShareholders(_to);
             pruneShareholders(_from, _value);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenysolutions/t-rex",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "A fully compliant environment for the issuance and use of tokenized securities.",
   "main": "index.js",
   "directories": {

--- a/test/tokenTransfer.test.js
+++ b/test/tokenTransfer.test.js
@@ -649,13 +649,15 @@ contract('Token', accounts => {
     await token.forcedTransfer(user1, user2, 300, { from: accounts[4] }).should.be.rejectedWith(EVMRevert);
   });
 
-  it('Forced transfer fails if exceeds partial freeze amount', async () => {
+  it('Forced transfer succeeds even if it exceeds partial freeze amount', async () => {
     await token.freezePartialTokens(user1, 800, { from: agent });
-    await token.forcedTransfer(user1, user2, 300, { from: agent }).should.be.rejectedWith(EVMRevert);
+    await token.forcedTransfer(user1, user2, 300, { from: agent }).should.be.fulfilled;
     const balance1 = await token.balanceOf(user1);
     const balance2 = await token.balanceOf(user2);
-    balance1.toString().should.equal('1000');
-    balance2.toString().should.equal('0');
+    const frozenTokens1 = await token.frozenTokens(user1);
+    balance1.toString().should.equal('700');
+    balance2.toString().should.equal('300');
+    frozenTokens1.toString().should.equal('700');
   });
 
   it('Forced transfer fails if balance is not enough', async () => {


### PR DESCRIPTION
forcedTransfer was not possible between partially frozen addresses, which should be the case if we don't want the agent to do 2 transactions (unfreezePartialTokens + forcedTransfer) in the case the amount of free tokens is lower than the amount to transfer, the goal of this PR is to solve this minor issue