### PR TITLE
new contracts : AgentManager and OwnerManager

### DIFF
--- a/contracts/compliance/DefaultCompliance.sol
+++ b/contracts/compliance/DefaultCompliance.sol
@@ -1,3 +1,26 @@
+/**
+ *     NOTICE
+ *
+ *     The T-REX software is licensed under a proprietary license or the GPL v.3.
+ *     If you choose to receive it under the GPL v.3 license, the following applies:
+ *     T-REX is a suite of smart contracts developed by Tokeny to manage and transfer financial assets on the ethereum blockchain
+ *
+ *     Copyright (C) 2019, Tokeny sàrl.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 pragma solidity ^0.6.0;
 
 import "./ICompliance.sol";

--- a/contracts/compliance/DefaultCompliance.sol
+++ b/contracts/compliance/DefaultCompliance.sol
@@ -1,8 +1,9 @@
 pragma solidity ^0.6.0;
 
 import "./ICompliance.sol";
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
-contract DefaultCompliance is ICompliance {
+contract DefaultCompliance is ICompliance, Ownable {
 
     /**
     * @notice checks that the transfer is compliant.
@@ -26,6 +27,10 @@ contract DefaultCompliance is ICompliance {
 
     function destroyed(address _from, uint256 _value) public override returns (bool) {
         return true;
+    }
+
+    function transferOwnershipOnComplianceContract(address newOwner) external override onlyOwner {
+        transferOwnership(newOwner);
     }
 }
 

--- a/contracts/compliance/ICompliance.sol
+++ b/contracts/compliance/ICompliance.sol
@@ -1,3 +1,26 @@
+/**
+ *     NOTICE
+ *
+ *     The T-REX software is licensed under a proprietary license or the GPL v.3.
+ *     If you choose to receive it under the GPL v.3 license, the following applies:
+ *     T-REX is a suite of smart contracts developed by Tokeny to manage and transfer financial assets on the ethereum blockchain
+ *
+ *     Copyright (C) 2019, Tokeny sàrl.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 pragma solidity ^0.6.0;
 
 interface ICompliance {

--- a/contracts/compliance/ICompliance.sol
+++ b/contracts/compliance/ICompliance.sol
@@ -5,4 +5,7 @@ interface ICompliance {
     function transferred(address _from, address _to, uint256 _value) external returns (bool);
     function created(address _to, uint256 _value) external returns (bool);
     function destroyed(address _from, uint256 _value) external returns (bool);
+
+    // transfer contract ownership
+    function transferOwnershipOnComplianceContract(address newOwner) external;
 }

--- a/contracts/compliance/LimitHolder.sol
+++ b/contracts/compliance/LimitHolder.sol
@@ -115,11 +115,8 @@ contract LimitHolder is ICompliance, AgentRole {
 
     function created(address _to, uint256 _value) public override onlyAgent returns (bool) {
         require(_value > 0, "No token created");
-        if (holderCount() < holderLimit) {
-            updateShareholders(_to);
-            return true;
-        }
-        return false;
+        updateShareholders(_to);
+        return true;
     }
 
     function destroyed(address _from, uint256 _value) public override onlyAgent returns (bool) {

--- a/contracts/compliance/LimitHolder.sol
+++ b/contracts/compliance/LimitHolder.sol
@@ -8,7 +8,7 @@ import "../registry/IIdentityRegistry.sol";
 contract LimitHolder is ICompliance, AgentRole {
     IToken public token;
     uint public holderLimit;
-    IIdentityRegistry private identityRegistry = token.getIdentityRegistry();
+    IIdentityRegistry private identityRegistry;
     mapping(address => uint256) private holderIndices;
     mapping(uint16 => uint256) private countryShareHolders;
     address[] private shareholders;
@@ -16,6 +16,7 @@ contract LimitHolder is ICompliance, AgentRole {
     constructor (address _token, uint _holderLimit) public {
         token = IToken(_token);
         holderLimit = _holderLimit;
+		identityRegistry = token.getIdentityRegistry();
     }
 
 
@@ -61,7 +62,7 @@ contract LimitHolder is ICompliance, AgentRole {
      *  @dev see https://ethereum.stackexchange.com/a/39311
      */
     function pruneShareholders(address addr, uint256 value) internal {
-        uint256 balance = token.balanceOf(addr) - value;
+        uint256 balance = token.balanceOf(addr);
         if (balance > 0) {
             return;
         }
@@ -97,7 +98,10 @@ contract LimitHolder is ICompliance, AgentRole {
     * @param _value The amount of tokens involved in the transfer
     */
     function canTransfer(address _from, address _to, uint256 _value) public override view returns (bool) {
-        if (holderCount() < holderLimit) {
+        if (holderIndices[_to] != 0) {
+			return true;
+		}
+		if (holderCount() < holderLimit) {
             return true;
         }
         return false;
@@ -111,8 +115,11 @@ contract LimitHolder is ICompliance, AgentRole {
 
     function created(address _to, uint256 _value) public override onlyAgent returns (bool) {
         require(_value > 0, "No token created");
-        updateShareholders(_to);
-        return true;
+        if (holderCount() < holderLimit) {
+        	updateShareholders(_to);
+        	return true;
+        }
+		return false;
     }
 
     function destroyed(address _from, uint256 _value) public override onlyAgent returns (bool) {

--- a/contracts/compliance/LimitHolder.sol
+++ b/contracts/compliance/LimitHolder.sol
@@ -1,3 +1,26 @@
+/**
+ *     NOTICE
+ *
+ *     The T-REX software is licensed under a proprietary license or the GPL v.3.
+ *     If you choose to receive it under the GPL v.3 license, the following applies:
+ *     T-REX is a suite of smart contracts developed by Tokeny to manage and transfer financial assets on the ethereum blockchain
+ *
+ *     Copyright (C) 2019, Tokeny sàrl.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 pragma solidity ^0.6.0;
 
 import "./ICompliance.sol";

--- a/contracts/compliance/LimitHolder.sol
+++ b/contracts/compliance/LimitHolder.sol
@@ -16,7 +16,7 @@ contract LimitHolder is ICompliance, AgentRole {
     constructor (address _token, uint _holderLimit) public {
         token = IToken(_token);
         holderLimit = _holderLimit;
-		identityRegistry = token.getIdentityRegistry();
+        identityRegistry = token.getIdentityRegistry();
     }
 
 
@@ -99,9 +99,9 @@ contract LimitHolder is ICompliance, AgentRole {
     */
     function canTransfer(address _from, address _to, uint256 _value) public override view returns (bool) {
         if (holderIndices[_to] != 0) {
-			return true;
-		}
-		if (holderCount() < holderLimit) {
+            return true;
+        }
+        if (holderCount() < holderLimit) {
             return true;
         }
         return false;
@@ -116,10 +116,10 @@ contract LimitHolder is ICompliance, AgentRole {
     function created(address _to, uint256 _value) public override onlyAgent returns (bool) {
         require(_value > 0, "No token created");
         if (holderCount() < holderLimit) {
-        	updateShareholders(_to);
-        	return true;
+            updateShareholders(_to);
+            return true;
         }
-		return false;
+        return false;
     }
 
     function destroyed(address _from, uint256 _value) public override onlyAgent returns (bool) {

--- a/contracts/compliance/LimitHolder.sol
+++ b/contracts/compliance/LimitHolder.sol
@@ -123,4 +123,8 @@ contract LimitHolder is ICompliance, AgentRole {
         pruneShareholders(_from, _value);
         return true;
     }
+
+    function transferOwnershipOnComplianceContract(address newOwner) external override onlyOwner {
+        transferOwnership(newOwner);
+    }
 }

--- a/contracts/registry/ClaimTopicsRegistry.sol
+++ b/contracts/registry/ClaimTopicsRegistry.sol
@@ -49,4 +49,8 @@ contract ClaimTopicsRegistry is IClaimTopicsRegistry, Ownable {
     function getClaimTopics() public override view returns (uint256[] memory) {
         return claimTopics;
     }
+
+    function transferOwnershipOnClaimTopicsRegistryContract(address newOwner) external override onlyOwner {
+        transferOwnership(newOwner);
+    }
 }

--- a/contracts/registry/ClaimTopicsRegistry.sol
+++ b/contracts/registry/ClaimTopicsRegistry.sol
@@ -1,3 +1,26 @@
+/**
+ *     NOTICE
+ *
+ *     The T-REX software is licensed under a proprietary license or the GPL v.3.
+ *     If you choose to receive it under the GPL v.3 license, the following applies:
+ *     T-REX is a suite of smart contracts developed by Tokeny to manage and transfer financial assets on the ethereum blockchain
+ *
+ *     Copyright (C) 2019, Tokeny sàrl.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 pragma solidity ^0.6.0;
 
 import "../registry/IClaimTopicsRegistry.sol";

--- a/contracts/registry/IClaimTopicsRegistry.sol
+++ b/contracts/registry/IClaimTopicsRegistry.sol
@@ -11,4 +11,7 @@ interface IClaimTopicsRegistry{
 
     // GETTERS
     function getClaimTopics() external view returns (uint256[] memory);
+
+    // transfer contract ownership
+    function transferOwnershipOnClaimTopicsRegistryContract(address newOwner) external;
 }

--- a/contracts/registry/IClaimTopicsRegistry.sol
+++ b/contracts/registry/IClaimTopicsRegistry.sol
@@ -1,3 +1,26 @@
+/**
+ *     NOTICE
+ *
+ *     The T-REX software is licensed under a proprietary license or the GPL v.3.
+ *     If you choose to receive it under the GPL v.3 license, the following applies:
+ *     T-REX is a suite of smart contracts developed by Tokeny to manage and transfer financial assets on the ethereum blockchain
+ *
+ *     Copyright (C) 2019, Tokeny sàrl.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 pragma solidity ^0.6.0;
 
 interface IClaimTopicsRegistry{

--- a/contracts/registry/IIdentityRegistry.sol
+++ b/contracts/registry/IIdentityRegistry.sol
@@ -1,3 +1,26 @@
+/**
+ *     NOTICE
+ *
+ *     The T-REX software is licensed under a proprietary license or the GPL v.3.
+ *     If you choose to receive it under the GPL v.3 license, the following applies:
+ *     T-REX is a suite of smart contracts developed by Tokeny to manage and transfer financial assets on the ethereum blockchain
+ *
+ *     Copyright (C) 2019, Tokeny sàrl.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 pragma solidity ^0.6.0;
 
 import "../registry/ITrustedIssuersRegistry.sol";

--- a/contracts/registry/IIdentityRegistry.sol
+++ b/contracts/registry/IIdentityRegistry.sol
@@ -33,4 +33,11 @@ interface IIdentityRegistry {
     function getInvestorCountryOfWallet(address _wallet) external view returns (uint16);
     function getIssuersRegistry() external view returns (ITrustedIssuersRegistry);
     function getTopicsRegistry() external view returns (IClaimTopicsRegistry);
+
+    // transfer contract ownership
+    function transferOwnershipOnIdentityRegistryContract(address newOwner) external;
+
+    // manage Agent Role (onlyOwner functions)
+    function addAgentOnIdentityRegistryContract(address agent) external;
+    function removeAgentOnIdentityRegistryContract(address agent) external;
 }

--- a/contracts/registry/ITrustedIssuersRegistry.sol
+++ b/contracts/registry/ITrustedIssuersRegistry.sol
@@ -19,4 +19,7 @@ interface ITrustedIssuersRegistry {
     function addTrustedIssuer(IClaimIssuer _trustedIssuer, uint index, uint[] calldata claimTopics) external;
     function removeTrustedIssuer(uint index) external;
     function updateIssuerContract(uint index, IClaimIssuer _newTrustedIssuer, uint[] calldata claimTopics) external;
+
+    // transfer contract ownership
+    function transferOwnershipOnIssuersRegistryContract(address newOwner) external;
 }

--- a/contracts/registry/ITrustedIssuersRegistry.sol
+++ b/contracts/registry/ITrustedIssuersRegistry.sol
@@ -1,3 +1,26 @@
+/**
+ *     NOTICE
+ *
+ *     The T-REX software is licensed under a proprietary license or the GPL v.3.
+ *     If you choose to receive it under the GPL v.3 license, the following applies:
+ *     T-REX is a suite of smart contracts developed by Tokeny to manage and transfer financial assets on the ethereum blockchain
+ *
+ *     Copyright (C) 2019, Tokeny sàrl.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 pragma solidity ^0.6.0;
 
 import "@onchain-id/solidity/contracts/IClaimIssuer.sol";
@@ -7,6 +30,7 @@ interface ITrustedIssuersRegistry {
     event TrustedIssuerAdded(uint indexed index, IClaimIssuer indexed trustedIssuer, uint[] claimTopics);
     event TrustedIssuerRemoved(uint indexed index, IClaimIssuer indexed trustedIssuer);
     event TrustedIssuerUpdated(uint indexed index, IClaimIssuer indexed oldTrustedIssuer, IClaimIssuer indexed newTrustedIssuer, uint[] claimTopics);
+    event ClaimTopicsUpdated(uint indexed index, IClaimIssuer indexed trustedIssuer, uint[] claimTopics);
 
     // READ OPERATIONS
     function getTrustedIssuer(uint index) external view returns (IClaimIssuer);
@@ -19,6 +43,7 @@ interface ITrustedIssuersRegistry {
     function addTrustedIssuer(IClaimIssuer _trustedIssuer, uint index, uint[] calldata claimTopics) external;
     function removeTrustedIssuer(uint index) external;
     function updateIssuerContract(uint index, IClaimIssuer _newTrustedIssuer, uint[] calldata claimTopics) external;
+    function updateIssuerClaimTopics(uint index, uint[] calldata claimTopics) external;
 
     // transfer contract ownership
     function transferOwnershipOnIssuersRegistryContract(address newOwner) external;

--- a/contracts/registry/IdentityRegistry.sol
+++ b/contracts/registry/IdentityRegistry.sol
@@ -213,4 +213,17 @@ contract IdentityRegistry is IIdentityRegistry, AgentRole {
 
         return true;
     }
+
+    function transferOwnershipOnIdentityRegistryContract(address newOwner) external override onlyOwner {
+        transferOwnership(newOwner);
+    }
+
+    function addAgentOnIdentityRegistryContract(address agent) external override {
+        addAgent(agent);
+    }
+
+    function removeAgentOnIdentityRegistryContract(address agent) external override {
+        removeAgent(agent);
+    }
+
 }

--- a/contracts/registry/IdentityRegistry.sol
+++ b/contracts/registry/IdentityRegistry.sol
@@ -1,3 +1,26 @@
+/**
+ *     NOTICE
+ *
+ *     The T-REX software is licensed under a proprietary license or the GPL v.3.
+ *     If you choose to receive it under the GPL v.3 license, the following applies:
+ *     T-REX is a suite of smart contracts developed by Tokeny to manage and transfer financial assets on the ethereum blockchain
+ *
+ *     Copyright (C) 2019, Tokeny sàrl.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 pragma solidity ^0.6.0;
 
 

--- a/contracts/registry/TrustedIssuersRegistry.sol
+++ b/contracts/registry/TrustedIssuersRegistry.sol
@@ -1,3 +1,26 @@
+/**
+ *     NOTICE
+ *
+ *     The T-REX software is licensed under a proprietary license or the GPL v.3.
+ *     If you choose to receive it under the GPL v.3 license, the following applies:
+ *     T-REX is a suite of smart contracts developed by Tokeny to manage and transfer financial assets on the ethereum blockchain
+ *
+ *     Copyright (C) 2019, Tokeny sàrl.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 pragma solidity ^0.6.0;
 
 
@@ -182,10 +205,25 @@ contract TrustedIssuersRegistry is ITrustedIssuersRegistry, Ownable {
         for (i = 0; i < claimTopicsLength; i++) {
             trustedIssuerClaimTopics[index][i] = claimTopics[i];
         }
+        delete trustedIssuer[address(trustedIssuers[index])];
+        trustedIssuer[address(_newTrustedIssuer)] = true;
         trustedIssuerClaimCount[index] = i;
         trustedIssuers[index] = _newTrustedIssuer;
 
         emit TrustedIssuerUpdated(index, trustedIssuers[index], _newTrustedIssuer, claimTopics);
+    }
+
+    function updateIssuerClaimTopics(uint index, uint[] memory claimTopics) public override onlyOwner {
+        require(index > 0 && index <= indexes.length);
+        uint claimTopicsLength = claimTopics.length;
+        require(claimTopicsLength > 0);
+        uint i;
+        for (i = 0; i < claimTopicsLength; i++) {
+            trustedIssuerClaimTopics[index][i] = claimTopics[i];
+        }
+        trustedIssuerClaimCount[index] = i;
+
+        emit ClaimTopicsUpdated(index, trustedIssuers[index], claimTopics);
     }
 
     function transferOwnershipOnIssuersRegistryContract(address newOwner) external override onlyOwner {

--- a/contracts/registry/TrustedIssuersRegistry.sol
+++ b/contracts/registry/TrustedIssuersRegistry.sol
@@ -187,4 +187,8 @@ contract TrustedIssuersRegistry is ITrustedIssuersRegistry, Ownable {
 
         emit TrustedIssuerUpdated(index, trustedIssuers[index], _newTrustedIssuer, claimTopics);
     }
+
+    function transferOwnershipOnIssuersRegistryContract(address newOwner) external override onlyOwner {
+        transferOwnership(newOwner);
+    }
 }

--- a/contracts/roles/AgentManager.sol
+++ b/contracts/roles/AgentManager.sol
@@ -1,3 +1,26 @@
+/**
+ *     NOTICE
+ *
+ *     The T-REX software is licensed under a proprietary license or the GPL v.3.
+ *     If you choose to receive it under the GPL v.3 license, the following applies:
+ *     T-REX is a suite of smart contracts developed by Tokeny to manage and transfer financial assets on the ethereum blockchain
+ *
+ *     Copyright (C) 2019, Tokeny sàrl.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 pragma solidity ^0.6.0;
 
 import "../token/IToken.sol";

--- a/contracts/roles/AgentManager.sol
+++ b/contracts/roles/AgentManager.sol
@@ -1,0 +1,83 @@
+pragma solidity ^0.6.0;
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "../token/IToken.sol";
+import "../registry/IIdentityRegistry.sol";
+import "./AgentRoles.sol";
+import "@onchain-id/solidity/contracts/IIdentity.sol";
+
+contract AgentManager is Ownable, AgentRoles {
+
+    IToken public token;
+    IIdentityRegistry public identityRegistry;
+
+
+    constructor (address _token) public {
+        token = IToken(_token);
+        identityRegistry = token.getIdentityRegistry();
+    }
+
+    function callForcedTransfer(address _from, address _to, uint256 _value, IIdentity onchainID) external {
+        require(isTransferManager(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Transfer Manager");
+        token.forcedTransfer(_from, _to, _value);
+    }
+
+    function callPause(IIdentity onchainID) external {
+        require(isFreezer(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Freezer");
+        token.pause();
+    }
+
+    function callUnpause(IIdentity onchainID) external {
+        require(isFreezer(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Freezer");
+        token.unpause();
+    }
+
+    function callMint(address _to, uint256 _amount, IIdentity onchainID) external {
+        require(isSupplyModifier(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Supply Modifier");
+        token.mint(_to, _amount);
+    }
+
+    function callBurn(address account, uint256 value, IIdentity onchainID) external {
+        require(isSupplyModifier(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Supply Modifier");
+        token.mint(account, value);
+    }
+
+    function callSetAddressFrozen(address addr, bool freeze, IIdentity onchainID) external {
+        require(isFreezer(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Freezer");
+        token.setAddressFrozen(addr, freeze);
+    }
+
+    function callFreezePartialTokens(address addr, uint256 amount, IIdentity onchainID) external {
+        require(isFreezer(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Freezer");
+        token.freezePartialTokens(addr, amount);
+    }
+
+    function callUnfreezePartialTokens(address addr, uint256 amount, IIdentity onchainID) external {
+        require(isFreezer(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Freezer");
+        token.unfreezePartialTokens(addr, amount);
+    }
+
+    function callRecoveryAddress(address wallet_lostAddress, address wallet_newAddress, address investorOnchainID, IIdentity onchainID) external {
+        require(isRecoveryAgent(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Recovery Agent");
+        token.recoveryAddress(wallet_lostAddress, wallet_newAddress, investorOnchainID);
+    }
+
+    function callRegisterIdentity(address _user, IIdentity _identity, uint16 _country, IIdentity onchainID) external {
+        require(isWhiteListManager(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT WhiteList Manager");
+        identityRegistry.registerIdentity(_user, _identity, _country);
+    }
+
+    function callUpdateIdentity(address _user, IIdentity _identity, IIdentity onchainID) external {
+        require(isWhiteListManager(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT WhiteList Manager");
+        identityRegistry.updateIdentity(_user, _identity);
+    }
+
+    function callUpdateCountry(address _user, uint16 _country, IIdentity onchainID) external {
+        require(isWhiteListManager(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT WhiteList Manager");
+        identityRegistry.updateCountry(_user, _country);
+    }
+
+    function callDeleteIdentity(address _user, IIdentity onchainID) external {
+        require(isWhiteListManager(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT WhiteList Manager");
+        identityRegistry.deleteIdentity(_user);
+    }
+}

--- a/contracts/roles/AgentManager.sol
+++ b/contracts/roles/AgentManager.sol
@@ -1,15 +1,14 @@
 pragma solidity ^0.6.0;
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+
 import "../token/IToken.sol";
 import "../registry/IIdentityRegistry.sol";
 import "./AgentRoles.sol";
 import "@onchain-id/solidity/contracts/IIdentity.sol";
 
-contract AgentManager is Ownable, AgentRoles {
+contract AgentManager is AgentRoles {
 
     IToken public token;
     IIdentityRegistry public identityRegistry;
-
 
     constructor (address _token) public {
         token = IToken(_token);

--- a/contracts/roles/AgentManager.sol
+++ b/contracts/roles/AgentManager.sol
@@ -20,6 +20,11 @@ contract AgentManager is AgentRoles {
         token.forcedTransfer(_from, _to, _value);
     }
 
+    function callBatchForcedTransfer(address[] calldata _fromList, address[] calldata _toList, uint256[] calldata _values, IIdentity onchainID) external {
+        require(isTransferManager(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Transfer Manager");
+        token.batchForcedTransfer(_fromList, _toList, _values);
+    }
+
     function callPause(IIdentity onchainID) external {
         require(isFreezer(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Freezer");
         token.pause();
@@ -35,9 +40,19 @@ contract AgentManager is AgentRoles {
         token.mint(_to, _amount);
     }
 
+    function callBatchMint(address[] calldata _toList, uint256[] calldata _amounts, IIdentity onchainID) external {
+        require(isSupplyModifier(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Supply Modifier");
+        token.batchMint(_toList, _amounts);
+    }
+
     function callBurn(address account, uint256 value, IIdentity onchainID) external {
         require(isSupplyModifier(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Supply Modifier");
-        token.mint(account, value);
+        token.burn(account, value);
+    }
+
+    function callBatchBurn(address[] calldata accounts, uint256[] calldata values, IIdentity onchainID) external {
+        require(isSupplyModifier(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Supply Modifier");
+        token.batchBurn(accounts, values);
     }
 
     function callSetAddressFrozen(address addr, bool freeze, IIdentity onchainID) external {
@@ -45,14 +60,29 @@ contract AgentManager is AgentRoles {
         token.setAddressFrozen(addr, freeze);
     }
 
+    function callBatchSetAddressFrozen(address[] calldata addrList, bool[] calldata freeze, IIdentity onchainID) external {
+        require(isFreezer(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Freezer");
+        token.batchSetAddressFrozen(addrList, freeze);
+    }
+
     function callFreezePartialTokens(address addr, uint256 amount, IIdentity onchainID) external {
         require(isFreezer(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Freezer");
         token.freezePartialTokens(addr, amount);
     }
 
+    function callBatchFreezePartialTokens(address[] calldata addrList, uint256[] calldata amounts, IIdentity onchainID) external {
+        require(isFreezer(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Freezer");
+        token.batchFreezePartialTokens(addrList, amounts);
+    }
+
     function callUnfreezePartialTokens(address addr, uint256 amount, IIdentity onchainID) external {
         require(isFreezer(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Freezer");
         token.unfreezePartialTokens(addr, amount);
+    }
+
+    function callBatchUnfreezePartialTokens(address[] calldata addrList, uint256[] calldata amounts, IIdentity onchainID) external {
+        require(isFreezer(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Freezer");
+        token.batchUnfreezePartialTokens(addrList, amounts);
     }
 
     function callRecoveryAddress(address wallet_lostAddress, address wallet_newAddress, address investorOnchainID, IIdentity onchainID) external {

--- a/contracts/roles/AgentManager.sol
+++ b/contracts/roles/AgentManager.sol
@@ -12,7 +12,6 @@ contract AgentManager is AgentRoles {
 
     constructor (address _token) public {
         token = IToken(_token);
-        identityRegistry = token.getIdentityRegistry();
     }
 
     function callForcedTransfer(address _from, address _to, uint256 _value, IIdentity onchainID) external {
@@ -92,21 +91,25 @@ contract AgentManager is AgentRoles {
 
     function callRegisterIdentity(address _user, IIdentity _identity, uint16 _country, IIdentity onchainID) external {
         require(isWhiteListManager(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT WhiteList Manager");
+        identityRegistry = token.getIdentityRegistry();
         identityRegistry.registerIdentity(_user, _identity, _country);
     }
 
     function callUpdateIdentity(address _user, IIdentity _identity, IIdentity onchainID) external {
         require(isWhiteListManager(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT WhiteList Manager");
+        identityRegistry = token.getIdentityRegistry();
         identityRegistry.updateIdentity(_user, _identity);
     }
 
     function callUpdateCountry(address _user, uint16 _country, IIdentity onchainID) external {
         require(isWhiteListManager(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT WhiteList Manager");
+        identityRegistry = token.getIdentityRegistry();
         identityRegistry.updateCountry(_user, _country);
     }
 
     function callDeleteIdentity(address _user, IIdentity onchainID) external {
         require(isWhiteListManager(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT WhiteList Manager");
+        identityRegistry = token.getIdentityRegistry();
         identityRegistry.deleteIdentity(_user);
     }
 }

--- a/contracts/roles/AgentRole.sol
+++ b/contracts/roles/AgentRole.sol
@@ -1,3 +1,26 @@
+/**
+ *     NOTICE
+ *
+ *     The T-REX software is licensed under a proprietary license or the GPL v.3.
+ *     If you choose to receive it under the GPL v.3 license, the following applies:
+ *     T-REX is a suite of smart contracts developed by Tokeny to manage and transfer financial assets on the ethereum blockchain
+ *
+ *     Copyright (C) 2019, Tokeny sàrl.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 pragma solidity ^0.6.0;
 
 import "openzeppelin-solidity/contracts/access/Roles.sol";

--- a/contracts/roles/AgentRoles.sol
+++ b/contracts/roles/AgentRoles.sol
@@ -28,12 +28,12 @@ contract AgentRoles is Ownable {
         return _agentAdmin.has(account);
     }
 
-    function addAgentAdmin(address account) public onlyOwner {
+    function addAgentAdmin(address account) public onlyAdmin {
         _agentAdmin.add(account);
         emit RoleAdded(account);
     }
 
-    function removeAgentAdmin(address account) public onlyOwner {
+    function removeAgentAdmin(address account) public onlyAdmin {
         _agentAdmin.remove(account);
         emit RoleRemoved(account);
     }

--- a/contracts/roles/AgentRoles.sol
+++ b/contracts/roles/AgentRoles.sol
@@ -6,8 +6,8 @@ import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 contract AgentRoles is Ownable {
     using Roles for Roles.Role;
 
-    event RoleAdded(address indexed account);
-    event RoleRemoved(address indexed account);
+    event RoleAdded(address indexed account, string role);
+    event RoleRemoved(address indexed account, string role);
 
     Roles.Role private _supplyModifiers;
     Roles.Role private _freezers;
@@ -30,12 +30,14 @@ contract AgentRoles is Ownable {
 
     function addAgentAdmin(address account) public onlyAdmin {
         _agentAdmin.add(account);
-        emit RoleAdded(account);
+        string memory role = "AgentAdmin";
+        emit RoleAdded(account, role);
     }
 
     function removeAgentAdmin(address account) public onlyAdmin {
         _agentAdmin.remove(account);
-        emit RoleRemoved(account);
+        string memory role = "AgentAdmin";
+        emit RoleRemoved(account, role);
     }
 
     // SupplyModifier Role _supplyModifiers
@@ -46,12 +48,14 @@ contract AgentRoles is Ownable {
 
     function addSupplyModifier(address account) public onlyAdmin {
         _supplyModifiers.add(account);
-        emit RoleAdded(account);
+        string memory role = "SupplyModifier";
+        emit RoleAdded(account, role);
     }
 
     function removeSupplyModifier(address account) public onlyAdmin {
         _supplyModifiers.remove(account);
-        emit RoleRemoved(account);
+        string memory role = "SupplyModifier";
+        emit RoleRemoved(account, role);
     }
 
     // Freezer Role _freezers
@@ -62,12 +66,14 @@ contract AgentRoles is Ownable {
 
     function addFreezer(address account) public onlyAdmin {
         _freezers.add(account);
-        emit RoleAdded(account);
+        string memory role = "Freezer";
+        emit RoleAdded(account, role);
     }
 
     function removeFreezer(address account) public onlyAdmin {
         _freezers.remove(account);
-        emit RoleRemoved(account);
+        string memory role = "Freezer";
+        emit RoleRemoved(account, role);
     }
 
     // TransferManager Role _transferManagers
@@ -78,12 +84,14 @@ contract AgentRoles is Ownable {
 
     function addTransferManager(address account) public onlyAdmin {
         _transferManagers.add(account);
-        emit RoleAdded(account);
+        string memory role = "TransferManager";
+        emit RoleAdded(account, role);
     }
 
     function removeTransferManager(address account) public onlyAdmin {
         _transferManagers.remove(account);
-        emit RoleRemoved(account);
+        string memory role = "TransferManager";
+        emit RoleRemoved(account, role);
     }
 
     // RecoveryAgent Role _recoveryAgents
@@ -94,12 +102,14 @@ contract AgentRoles is Ownable {
 
     function addRecoveryAgent(address account) public onlyAdmin {
         _recoveryAgents.add(account);
-        emit RoleAdded(account);
+        string memory role = "RecoveryAgent";
+        emit RoleAdded(account, role);
     }
 
     function removeRecoveryAgent(address account) public onlyAdmin {
         _recoveryAgents.remove(account);
-        emit RoleRemoved(account);
+        string memory role = "RecoveryAgent";
+        emit RoleRemoved(account, role);
     }
 
     // ComplianceAgent Role _complianceAgents
@@ -110,12 +120,14 @@ contract AgentRoles is Ownable {
 
     function addComplianceAgent(address account) public onlyAdmin {
         _complianceAgents.add(account);
-        emit RoleAdded(account);
+        string memory role = "ComplianceAgent";
+        emit RoleAdded(account, role);
     }
 
     function removeComplianceAgent(address account) public onlyAdmin {
         _complianceAgents.remove(account);
-        emit RoleRemoved(account);
+        string memory role = "ComplianceAgent";
+        emit RoleRemoved(account, role);
     }
 
     // WhiteListManager Role _whiteListManagers
@@ -126,11 +138,13 @@ contract AgentRoles is Ownable {
 
     function addWhiteListManager(address account) public onlyAdmin {
         _whiteListManagers.add(account);
-        emit RoleAdded(account);
+        string memory role = "WhiteListManager";
+        emit RoleAdded(account, role);
     }
 
     function removeWhiteListManager(address account) public onlyAdmin {
         _whiteListManagers.remove(account);
-        emit RoleRemoved(account);
+        string memory role = "WhiteListManager";
+        emit RoleRemoved(account, role);
     }
 }

--- a/contracts/roles/AgentRoles.sol
+++ b/contracts/roles/AgentRoles.sol
@@ -1,0 +1,117 @@
+pragma solidity ^0.6.0;
+
+import "openzeppelin-solidity/contracts/access/Roles.sol";
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+
+contract AgentRoles is Ownable {
+    using Roles for Roles.Role;
+
+    event RoleAdded(address indexed account);
+    event RoleRemoved(address indexed account);
+
+    Roles.Role private _supplyModifiers;
+    Roles.Role private _freezers;
+    Roles.Role private _transferManagers;
+    Roles.Role private _recoveryAgents;
+    Roles.Role private _complianceAgents;
+    Roles.Role private _whiteListManagers;
+
+
+    // SupplyModifier Role _supplyModifiers
+
+    function isSupplyModifier(address account) public view returns (bool) {
+        return _supplyModifiers.has(account);
+    }
+
+    function addSupplyModifier(address account) public onlyOwner {
+        _supplyModifiers.add(account);
+        emit RoleAdded(account);
+    }
+
+    function removeSupplyModifier(address account) public onlyOwner {
+        _supplyModifiers.remove(account);
+        emit RoleRemoved(account);
+    }
+
+    // Freezer Role _freezers
+
+    function isFreezer(address account) public view returns (bool) {
+        return _freezers.has(account);
+    }
+
+    function addFreezer(address account) public onlyOwner {
+        _freezers.add(account);
+        emit RoleAdded(account);
+    }
+
+    function removeFreezer(address account) public onlyOwner {
+        _freezers.remove(account);
+        emit RoleRemoved(account);
+    }
+
+    // TransferManager Role _transferManagers
+
+    function isTransferManager(address account) public view returns (bool) {
+        return _transferManagers.has(account);
+    }
+
+    function addTransferManager(address account) public onlyOwner {
+        _transferManagers.add(account);
+        emit RoleAdded(account);
+    }
+
+    function removeTransferManager(address account) public onlyOwner {
+        _transferManagers.remove(account);
+        emit RoleRemoved(account);
+    }
+
+    // RecoveryAgent Role _recoveryAgents
+
+    function isRecoveryAgent(address account) public view returns (bool) {
+        return _recoveryAgents.has(account);
+    }
+
+    function addRecoveryAgent(address account) public onlyOwner {
+        _recoveryAgents.add(account);
+        emit RoleAdded(account);
+    }
+
+    function removeRecoveryAgent(address account) public onlyOwner {
+        _recoveryAgents.remove(account);
+        emit RoleRemoved(account);
+    }
+
+    // ComplianceAgent Role _complianceAgents
+
+    function isComplianceAgent(address account) public view returns (bool) {
+        return _complianceAgents.has(account);
+    }
+
+    function addComplianceAgent(address account) public onlyOwner {
+        _complianceAgents.add(account);
+        emit RoleAdded(account);
+    }
+
+    function removeComplianceAgent(address account) public onlyOwner {
+        _complianceAgents.remove(account);
+        emit RoleRemoved(account);
+    }
+
+    // WhiteListManager Role _whiteListManagers
+
+    function isWhiteListManager(address account) public view returns (bool) {
+        return _whiteListManagers.has(account);
+    }
+
+    function addWhiteListManager(address account) public onlyOwner {
+        _whiteListManagers.add(account);
+        emit RoleAdded(account);
+    }
+
+    function removeWhiteListManager(address account) public onlyOwner {
+        _whiteListManagers.remove(account);
+        emit RoleRemoved(account);
+    }
+
+
+}

--- a/contracts/roles/AgentRoles.sol
+++ b/contracts/roles/AgentRoles.sol
@@ -1,3 +1,26 @@
+/**
+ *     NOTICE
+ *
+ *     The T-REX software is licensed under a proprietary license or the GPL v.3.
+ *     If you choose to receive it under the GPL v.3 license, the following applies:
+ *     T-REX is a suite of smart contracts developed by Tokeny to manage and transfer financial assets on the ethereum blockchain
+ *
+ *     Copyright (C) 2019, Tokeny sàrl.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 pragma solidity ^0.6.0;
 
 import "openzeppelin-solidity/contracts/access/Roles.sol";

--- a/contracts/roles/AgentRoles.sol
+++ b/contracts/roles/AgentRoles.sol
@@ -15,7 +15,28 @@ contract AgentRoles is Ownable {
     Roles.Role private _recoveryAgents;
     Roles.Role private _complianceAgents;
     Roles.Role private _whiteListManagers;
+    Roles.Role private _agentAdmin;
 
+    modifier onlyAdmin() {
+        require(isOwner() || isAgentAdmin(_msgSender()), "Role: Sender is NOT Admin");
+        _;
+    }
+
+    // AgentAdmin Role _agentAdmin
+
+    function isAgentAdmin(address account) public view returns (bool) {
+        return _agentAdmin.has(account);
+    }
+
+    function addAgentAdmin(address account) public onlyOwner {
+        _agentAdmin.add(account);
+        emit RoleAdded(account);
+    }
+
+    function removeAgentAdmin(address account) public onlyOwner {
+        _agentAdmin.remove(account);
+        emit RoleRemoved(account);
+    }
 
     // SupplyModifier Role _supplyModifiers
 
@@ -23,12 +44,12 @@ contract AgentRoles is Ownable {
         return _supplyModifiers.has(account);
     }
 
-    function addSupplyModifier(address account) public onlyOwner {
+    function addSupplyModifier(address account) public onlyAdmin {
         _supplyModifiers.add(account);
         emit RoleAdded(account);
     }
 
-    function removeSupplyModifier(address account) public onlyOwner {
+    function removeSupplyModifier(address account) public onlyAdmin {
         _supplyModifiers.remove(account);
         emit RoleRemoved(account);
     }
@@ -39,12 +60,12 @@ contract AgentRoles is Ownable {
         return _freezers.has(account);
     }
 
-    function addFreezer(address account) public onlyOwner {
+    function addFreezer(address account) public onlyAdmin {
         _freezers.add(account);
         emit RoleAdded(account);
     }
 
-    function removeFreezer(address account) public onlyOwner {
+    function removeFreezer(address account) public onlyAdmin {
         _freezers.remove(account);
         emit RoleRemoved(account);
     }
@@ -55,12 +76,12 @@ contract AgentRoles is Ownable {
         return _transferManagers.has(account);
     }
 
-    function addTransferManager(address account) public onlyOwner {
+    function addTransferManager(address account) public onlyAdmin {
         _transferManagers.add(account);
         emit RoleAdded(account);
     }
 
-    function removeTransferManager(address account) public onlyOwner {
+    function removeTransferManager(address account) public onlyAdmin {
         _transferManagers.remove(account);
         emit RoleRemoved(account);
     }
@@ -71,12 +92,12 @@ contract AgentRoles is Ownable {
         return _recoveryAgents.has(account);
     }
 
-    function addRecoveryAgent(address account) public onlyOwner {
+    function addRecoveryAgent(address account) public onlyAdmin {
         _recoveryAgents.add(account);
         emit RoleAdded(account);
     }
 
-    function removeRecoveryAgent(address account) public onlyOwner {
+    function removeRecoveryAgent(address account) public onlyAdmin {
         _recoveryAgents.remove(account);
         emit RoleRemoved(account);
     }
@@ -87,12 +108,12 @@ contract AgentRoles is Ownable {
         return _complianceAgents.has(account);
     }
 
-    function addComplianceAgent(address account) public onlyOwner {
+    function addComplianceAgent(address account) public onlyAdmin {
         _complianceAgents.add(account);
         emit RoleAdded(account);
     }
 
-    function removeComplianceAgent(address account) public onlyOwner {
+    function removeComplianceAgent(address account) public onlyAdmin {
         _complianceAgents.remove(account);
         emit RoleRemoved(account);
     }
@@ -103,15 +124,13 @@ contract AgentRoles is Ownable {
         return _whiteListManagers.has(account);
     }
 
-    function addWhiteListManager(address account) public onlyOwner {
+    function addWhiteListManager(address account) public onlyAdmin {
         _whiteListManagers.add(account);
         emit RoleAdded(account);
     }
 
-    function removeWhiteListManager(address account) public onlyOwner {
+    function removeWhiteListManager(address account) public onlyAdmin {
         _whiteListManagers.remove(account);
         emit RoleRemoved(account);
     }
-
-
 }

--- a/contracts/roles/OwnerManager.sol
+++ b/contracts/roles/OwnerManager.sol
@@ -1,0 +1,130 @@
+pragma solidity ^0.6.0;
+
+import "../token/IToken.sol";
+import "../registry/IIdentityRegistry.sol";
+import "../registry/ITrustedIssuersRegistry.sol";
+import "../registry/IClaimTopicsRegistry.sol";
+import "../compliance/ICompliance.sol";
+import "./OwnerRoles.sol";
+import "@onchain-id/solidity/contracts/IIdentity.sol";
+import "@onchain-id/solidity/contracts/IClaimIssuer.sol";
+
+contract OwnerManager is OwnerRoles {
+
+    IToken public token;
+    IIdentityRegistry public identityRegistry;
+    ITrustedIssuersRegistry public issuersRegistry;
+    IClaimTopicsRegistry public topicsRegistry;
+    ICompliance public compliance;
+
+
+    constructor (address _token) public {
+        token = IToken(_token);
+    }
+
+    function callSetIdentityRegistry(address _identityRegistry, IIdentity onchainID) external {
+        require(isRegistryAddressSetter(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Registry Address Setter");
+        token.setIdentityRegistry(_identityRegistry);
+    }
+
+    function callSetCompliance(address _compliance, IIdentity onchainID) external {
+        require(isComplianceSetter(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Compliance Setter");
+        token.setCompliance(_compliance);
+    }
+
+    function callSetTokenInformation(string calldata _name, string calldata _symbol, uint8 _decimals, string calldata _version, address _onchainID, IIdentity onchainID) external {
+        require(isTokenInfoManager(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Token Information Manager");
+        token.setTokenInformation(_name, _symbol, _decimals, _version, _onchainID);
+    }
+
+    function callSetClaimTopicsRegistry(address _claimTopicsRegistry, IIdentity onchainID) external {
+        require(isRegistryAddressSetter(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Registry Address Setter");
+        identityRegistry = token.getIdentityRegistry();
+        identityRegistry.setClaimTopicsRegistry(_claimTopicsRegistry);
+    }
+
+    function callSetTrustedIssuersRegistry(address _trustedIssuersRegistry, IIdentity onchainID) external {
+        require(isRegistryAddressSetter(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Registry Address Setter");
+        identityRegistry = token.getIdentityRegistry();
+        identityRegistry.setTrustedIssuersRegistry(_trustedIssuersRegistry);
+    }
+
+    function callAddTrustedIssuer(IClaimIssuer _trustedIssuer, uint index, uint[] calldata claimTopics, IIdentity onchainID) external {
+        require(isIssuersRegistryManager(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT IssuersRegistryManager");
+        identityRegistry = token.getIdentityRegistry();
+        issuersRegistry = identityRegistry.getIssuersRegistry();
+        issuersRegistry.addTrustedIssuer(_trustedIssuer, index, claimTopics);
+    }
+
+    function callRemoveTrustedIssuer(uint index, IIdentity onchainID) external {
+        require(isIssuersRegistryManager(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT IssuersRegistryManager");
+        identityRegistry = token.getIdentityRegistry();
+        issuersRegistry = identityRegistry.getIssuersRegistry();
+        issuersRegistry.removeTrustedIssuer(index);
+    }
+
+    function callUpdateIssuerContract(uint index, IClaimIssuer _newTrustedIssuer, uint[] calldata claimTopics, IIdentity onchainID) external {
+        require(isIssuersRegistryManager(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT IssuersRegistryManager");
+        identityRegistry = token.getIdentityRegistry();
+        issuersRegistry = identityRegistry.getIssuersRegistry();
+        issuersRegistry.updateIssuerContract(index, _newTrustedIssuer, claimTopics);
+    }
+
+    function callAddClaimTopic(uint256 claimTopic, IIdentity onchainID) external {
+        require(isClaimRegistryManager(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT ClaimRegistryManager");
+        identityRegistry = token.getIdentityRegistry();
+        topicsRegistry = identityRegistry.getTopicsRegistry();
+        topicsRegistry.addClaimTopic(claimTopic);
+    }
+
+    function callRemoveClaimTopic(uint256 claimTopic, IIdentity onchainID) external {
+        require(isClaimRegistryManager(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT ClaimRegistryManager");
+        identityRegistry = token.getIdentityRegistry();
+        topicsRegistry = identityRegistry.getTopicsRegistry();
+        topicsRegistry.removeClaimTopic(claimTopic);
+    }
+
+    function callTransferOwnershipOnTokenContract(address newOwner) external onlyAdmin {
+        token.transferOwnershipOnTokenContract(newOwner);
+    }
+
+    function callTransferOwnershipOnIdentityRegistryContract(address newOwner) external onlyAdmin {
+        identityRegistry = token.getIdentityRegistry();
+        identityRegistry.transferOwnershipOnIdentityRegistryContract(newOwner);
+    }
+
+    function callTransferOwnershipOnComplianceContract(address newOwner) external onlyAdmin {
+        compliance = token.getCompliance();
+        compliance.transferOwnershipOnComplianceContract(newOwner);
+    }
+
+    function callTransferOwnershipOnClaimTopicsRegistryContract(address newOwner) external onlyAdmin {
+        identityRegistry = token.getIdentityRegistry();
+        topicsRegistry = identityRegistry.getTopicsRegistry();
+        topicsRegistry.transferOwnershipOnClaimTopicsRegistryContract(newOwner);
+    }
+
+    function callTransferOwnershipOnIssuersRegistryContract(address newOwner) external onlyAdmin {
+        identityRegistry = token.getIdentityRegistry();
+        issuersRegistry = identityRegistry.getIssuersRegistry();
+        issuersRegistry.transferOwnershipOnIssuersRegistryContract(newOwner);
+    }
+
+    function callAddAgentOnTokenContract(address agent) external onlyAdmin {
+        token.addAgentOnTokenContract(agent);
+    }
+
+    function callRemoveAgentOnTokenContract(address agent) external onlyAdmin {
+        token.removeAgentOnTokenContract(agent);
+    }
+
+    function callAddAgentOnIdentityRegistryContract(address agent) external onlyAdmin {
+        identityRegistry = token.getIdentityRegistry();
+        identityRegistry.addAgentOnIdentityRegistryContract(agent);
+    }
+
+    function callRemoveAgentOnIdentityRegistryContract(address agent) external onlyAdmin {
+        identityRegistry = token.getIdentityRegistry();
+        identityRegistry.removeAgentOnIdentityRegistryContract(agent);
+    }
+}

--- a/contracts/roles/OwnerManager.sol
+++ b/contracts/roles/OwnerManager.sol
@@ -1,3 +1,26 @@
+/**
+ *     NOTICE
+ *
+ *     The T-REX software is licensed under a proprietary license or the GPL v.3.
+ *     If you choose to receive it under the GPL v.3 license, the following applies:
+ *     T-REX is a suite of smart contracts developed by Tokeny to manage and transfer financial assets on the ethereum blockchain
+ *
+ *     Copyright (C) 2019, Tokeny sàrl.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 pragma solidity ^0.6.0;
 
 import "../token/IToken.sol";
@@ -68,6 +91,13 @@ contract OwnerManager is OwnerRoles {
         identityRegistry = token.getIdentityRegistry();
         issuersRegistry = identityRegistry.getIssuersRegistry();
         issuersRegistry.updateIssuerContract(index, _newTrustedIssuer, claimTopics);
+    }
+
+    function callUpdateIssuerClaimTopics(uint index, uint[] calldata claimTopics, IIdentity onchainID) external {
+        require(isIssuersRegistryManager(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT IssuersRegistryManager");
+        identityRegistry = token.getIdentityRegistry();
+        issuersRegistry = identityRegistry.getIssuersRegistry();
+        issuersRegistry.updateIssuerClaimTopics(index, claimTopics);
     }
 
     function callAddClaimTopic(uint256 claimTopic, IIdentity onchainID) external {

--- a/contracts/roles/OwnerRoles.sol
+++ b/contracts/roles/OwnerRoles.sol
@@ -1,0 +1,131 @@
+pragma solidity ^0.6.0;
+
+import "openzeppelin-solidity/contracts/access/Roles.sol";
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+
+contract OwnerRoles is Ownable {
+    using Roles for Roles.Role;
+
+    event RoleAdded(address indexed account, string role);
+    event RoleRemoved(address indexed account, string role);
+
+    Roles.Role private _ownerAdmin;
+    Roles.Role private _registryAddressSetter;
+    Roles.Role private _complianceSetter;
+    Roles.Role private _claimRegistryManager;
+    Roles.Role private _issuersRegistryManager;
+    Roles.Role private _tokenInfoManager;
+
+    modifier onlyAdmin() {
+        require(isOwner() || isOwnerAdmin(_msgSender()), "Role: Sender is NOT Admin");
+        _;
+    }
+
+    // OwnerAdmin Role _ownerAdmin
+
+    function isOwnerAdmin(address account) public view returns (bool) {
+        return _ownerAdmin.has(account);
+    }
+
+    function addOwnerAdmin(address account) public onlyAdmin {
+        _ownerAdmin.add(account);
+        string memory role = "OwnerAdmin";
+        emit RoleAdded(account, role);
+    }
+
+    function removeOwnerAdmin(address account) public onlyAdmin {
+        _ownerAdmin.remove(account);
+        string memory role = "OwnerAdmin";
+        emit RoleRemoved(account, role);
+    }
+
+    // RegistryAddressSetter Role _registryAddressSetter
+
+    function isRegistryAddressSetter(address account) public view returns (bool) {
+        return _registryAddressSetter.has(account);
+    }
+
+    function addRegistryAddressSetter(address account) public onlyAdmin {
+        _registryAddressSetter.add(account);
+        string memory role = "RegistryAddressSetter";
+        emit RoleAdded(account, role);
+    }
+
+    function removeRegistryAddressSetter(address account) public onlyAdmin {
+        _registryAddressSetter.remove(account);
+        string memory role = "RegistryAddressSetter";
+        emit RoleRemoved(account, role);
+    }
+
+    // ComplianceSetter Role _complianceSetter
+
+    function isComplianceSetter(address account) public view returns (bool) {
+        return _complianceSetter.has(account);
+    }
+
+    function addComplianceSetter(address account) public onlyAdmin {
+        _complianceSetter.add(account);
+        string memory role = "ComplianceSetter";
+        emit RoleAdded(account, role);
+    }
+
+    function removeComplianceSetter(address account) public onlyAdmin {
+        _complianceSetter.remove(account);
+        string memory role = "ComplianceSetter";
+        emit RoleRemoved(account, role);
+    }
+
+    // ClaimRegistryManager Role _claimRegistryManager
+
+    function isClaimRegistryManager(address account) public view returns (bool) {
+        return _claimRegistryManager.has(account);
+    }
+
+    function addClaimRegistryManager(address account) public onlyAdmin {
+        _claimRegistryManager.add(account);
+        string memory role = "ClaimRegistryManager";
+        emit RoleAdded(account, role);
+    }
+
+    function removeClaimRegistryManager(address account) public onlyAdmin {
+        _claimRegistryManager.remove(account);
+        string memory role = "ClaimRegistryManager";
+        emit RoleRemoved(account, role);
+    }
+
+    // IssuersRegistryManager Role _issuersRegistryManager
+
+    function isIssuersRegistryManager(address account) public view returns (bool) {
+        return _issuersRegistryManager.has(account);
+    }
+
+    function addIssuersRegistryManager(address account) public onlyAdmin {
+        _issuersRegistryManager.add(account);
+        string memory role = "IssuersRegistryManager";
+        emit RoleAdded(account, role);
+    }
+
+    function removeIssuersRegistryManager(address account) public onlyAdmin {
+        _issuersRegistryManager.remove(account);
+        string memory role = "IssuersRegistryManager";
+        emit RoleRemoved(account, role);
+    }
+
+    // TokenInfoManager Role _tokenInfoManager
+
+    function isTokenInfoManager(address account) public view returns (bool) {
+        return _tokenInfoManager.has(account);
+    }
+
+    function addTokenInfoManager(address account) public onlyAdmin {
+        _tokenInfoManager.add(account);
+        string memory role = "TokenInfoManager";
+        emit RoleAdded(account, role);
+    }
+
+    function removeTokenInfoManager(address account) public onlyAdmin {
+        _tokenInfoManager.remove(account);
+        string memory role = "TokenInfoManager";
+        emit RoleRemoved(account, role);
+    }
+}

--- a/contracts/roles/OwnerRoles.sol
+++ b/contracts/roles/OwnerRoles.sol
@@ -1,3 +1,26 @@
+/**
+ *     NOTICE
+ *
+ *     The T-REX software is licensed under a proprietary license or the GPL v.3.
+ *     If you choose to receive it under the GPL v.3 license, the following applies:
+ *     T-REX is a suite of smart contracts developed by Tokeny to manage and transfer financial assets on the ethereum blockchain
+ *
+ *     Copyright (C) 2019, Tokeny sàrl.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 pragma solidity ^0.6.0;
 
 import "openzeppelin-solidity/contracts/access/Roles.sol";

--- a/contracts/token/IToken.sol
+++ b/contracts/token/IToken.sol
@@ -40,6 +40,8 @@ interface IToken is IERC20 {
     function getIdentityRegistry() external view returns (IIdentityRegistry);
     function getCompliance() external view returns (ICompliance);
     function paused() external view returns (bool);
+    function isFrozen(address addr) external view returns (bool);
+    function getFrozenTokens(address addr) external view returns (uint256);
 
 
     // setters

--- a/contracts/token/IToken.sol
+++ b/contracts/token/IToken.sol
@@ -36,8 +36,8 @@ interface IToken is IERC20{
     function recoveryAddress(address lostWallet, address newWallet, address investorOnchainID) external returns (bool);
     function batchTransfer(address[] calldata _toList, uint256[] calldata _values) external;
     function batchForcedTransfer(address[] calldata _fromList, address[] calldata _toList, uint256[] calldata _values) external;
-    function batchMint(address[] calldata _to, uint256[] calldata _amount) external;
-    function batchBurn(address[] calldata account, uint256[] calldata value) external;
+    function batchMint(address[] calldata _toList, uint256[] calldata _amounts) external;
+    function batchBurn(address[] calldata accounts, uint256[] calldata values) external;
     function batchSetAddressFrozen(address[] calldata addrList, bool[] calldata freeze) external;
     function batchFreezePartialTokens(address[] calldata addrList, uint256[] calldata amounts) external;
     function batchUnfreezePartialTokens(address[] calldata addrList, uint256[] calldata amounts) external;

--- a/contracts/token/IToken.sol
+++ b/contracts/token/IToken.sol
@@ -1,3 +1,26 @@
+/**
+ *     NOTICE
+ *
+ *     The T-REX software is licensed under a proprietary license or the GPL v.3.
+ *     If you choose to receive it under the GPL v.3 license, the following applies:
+ *     T-REX is a suite of smart contracts developed by Tokeny to manage and transfer financial assets on the ethereum blockchain
+ *
+ *     Copyright (C) 2019, Tokeny sàrl.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 pragma solidity ^0.6.0;
 
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";

--- a/contracts/token/IToken.sol
+++ b/contracts/token/IToken.sol
@@ -5,7 +5,7 @@ import "../registry/IIdentityRegistry.sol";
 import "../compliance/ICompliance.sol";
 
 //interface
-interface IToken is IERC20{
+interface IToken is IERC20 {
     event UpdatedTokenInformation(string newName, string newSymbol, uint8 newDecimals, string newVersion, address newOnchainID);
 
     // getters
@@ -41,4 +41,12 @@ interface IToken is IERC20{
     function batchSetAddressFrozen(address[] calldata addrList, bool[] calldata freeze) external;
     function batchFreezePartialTokens(address[] calldata addrList, uint256[] calldata amounts) external;
     function batchUnfreezePartialTokens(address[] calldata addrList, uint256[] calldata amounts) external;
+
+    // transfer contract ownership
+    function transferOwnershipOnTokenContract(address newOwner) external;
+
+    // manage Agent Role (onlyOwner functions)
+    function addAgentOnTokenContract(address agent) external;
+    function removeAgentOnTokenContract(address agent) external;
+
 }

--- a/contracts/token/Token.sol
+++ b/contracts/token/Token.sol
@@ -283,17 +283,6 @@ contract Token is IToken, Context, AgentRole {
     }
 
     /**
-     * @dev Destroys `amount` tokens from `account`.`amount` is then deducted
-     * from the caller's allowance.
-     *
-     * See {_burn} and {_approve}.
-     */
-    function _burnFrom(address account, uint256 amount) internal virtual {
-        _burn(account, amount);
-        _approve(account, _msgSender(), _allowances[account][_msgSender()].sub(amount, "ERC20: burn amount exceeds allowance"));
-    }
-
-    /**
      * @dev Hook that is called before any transfer of tokens. This includes
      * minting and burning.
      *

--- a/contracts/token/Token.sol
+++ b/contracts/token/Token.sol
@@ -531,9 +531,9 @@ contract Token is IToken, Context, AgentRole {
         compliance.created(_to, _amount);
     }
 
-    function batchMint(address[] calldata _to, uint256[] calldata _amount) external override {
-        for (uint256 i = 0; i < _to.length; i++) {
-            mint(_to[i], _amount[i]);
+    function batchMint(address[] calldata _toList, uint256[] calldata _amounts) external override {
+        for (uint256 i = 0; i < _toList.length; i++) {
+            mint(_toList[i], _amounts[i]);
         }
     }
 
@@ -542,9 +542,9 @@ contract Token is IToken, Context, AgentRole {
         compliance.destroyed(account, value);
     }
 
-    function batchBurn(address[] calldata account, uint256[] calldata value) external override {
-        for (uint256 i = 0; i < account.length; i++) {
-            burn(account[i], value[i]);
+    function batchBurn(address[] calldata accounts, uint256[] calldata values) external override {
+        for (uint256 i = 0; i < accounts.length; i++) {
+            burn(accounts[i], values[i]);
         }
     }
 

--- a/contracts/token/Token.sol
+++ b/contracts/token/Token.sol
@@ -526,9 +526,9 @@ contract Token is IToken, Context, AgentRole {
      */
     function mint(address _to, uint256 _amount) public override onlyAgent {
         require(identityRegistry.isVerified(_to), "Identity is not verified.");
-
-        _mint(_to, _amount);
-        compliance.created(_to, _amount);
+		if(compliance.created(_to, _amount)) {
+			_mint(_to, _amount);
+		}
     }
 
     function batchMint(address[] calldata _toList, uint256[] calldata _amounts) external override {

--- a/contracts/token/Token.sol
+++ b/contracts/token/Token.sol
@@ -1,3 +1,26 @@
+/**
+ *     NOTICE
+ *
+ *     The T-REX software is licensed under a proprietary license or the GPL v.3.
+ *     If you choose to receive it under the GPL v.3 license, the following applies:
+ *     T-REX is a suite of smart contracts developed by Tokeny to manage and transfer financial assets on the ethereum blockchain
+ *
+ *     Copyright (C) 2019, Tokeny sàrl.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 pragma solidity ^0.6.0;
 
 import "./IToken.sol";
@@ -35,26 +58,25 @@ contract Token is IToken, Context, AgentRole {
 
     event ComplianceAdded(address indexed _compliance);
 
-    event AddressFrozen(
-        address indexed addr,
-        bool indexed isFrozen,
-        address indexed owner
-    );
+    event RecoverySuccess(address wallet_lostAddress, address wallet_newAddress, address onchainID);
 
-    event RecoverySuccess(
-        address wallet_lostAddress,
-        address wallet_newAddress,
-        address onchainID
-    );
+    event RecoveryFails(address wallet_lostAddress, address wallet_newAddress, address onchainID);
 
-    event RecoveryFails(
-        address wallet_lostAddress,
-        address wallet_newAddress,
-        address onchainID
-    );
+    /**
+     * @dev Emitted when `owner` freeze/unfreeze the wallet `addr`.
+     * if `isFrozen` equals `true` the wallet is frozen
+     * if `isFrozen` equals `false` the wallet is unfrozen
+     */
+    event AddressFrozen(address indexed addr, bool indexed isFrozen, address indexed owner);
 
+    /**
+     * @dev Emitted when `amount` of tokens are partially frozen on the wallet `addr`.
+     */
     event TokensFrozen(address indexed addr, uint256 amount);
 
+    /**
+     * @dev Emitted when `amount` of tokens are partially unfrozen on the wallet `addr`.
+     */
     event TokensUnfrozen(address indexed addr, uint256 amount);
 
     /**

--- a/contracts/token/Token.sol
+++ b/contracts/token/Token.sol
@@ -526,7 +526,7 @@ contract Token is IToken, Context, AgentRole {
      */
     function mint(address _to, uint256 _amount) public override onlyAgent {
         require(identityRegistry.isVerified(_to), "Identity is not verified.");
-        if(compliance.created(_to, _amount)) {
+        if (compliance.created(_to, _amount)) {
             _mint(_to, _amount);
         }
     }

--- a/contracts/token/Token.sol
+++ b/contracts/token/Token.sol
@@ -11,7 +11,6 @@ import "../roles/AgentRole.sol";
 import "openzeppelin-solidity/contracts/GSN/Context.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
-import "openzeppelin-solidity/contracts/access/Roles.sol";
 
 contract Token is IToken, Context, AgentRole {
     using SafeMath for uint256;
@@ -538,6 +537,11 @@ contract Token is IToken, Context, AgentRole {
     }
 
     function burn(address account, uint256 value) public override onlyAgent {
+        uint256 freeBalance = balanceOf(account) - frozenTokens[account];
+        if (value > freeBalance) {
+            uint256 tokensToUnfreeze = value - freeBalance;
+            frozenTokens[account] -= tokensToUnfreeze;
+        }
         _burn(account, value);
         compliance.destroyed(account, value);
     }

--- a/contracts/token/Token.sol
+++ b/contracts/token/Token.sol
@@ -659,4 +659,15 @@ contract Token is IToken, Context, AgentRole {
         emit RecoveryFails(wallet_lostAddress, wallet_newAddress, investorOnchainID);
         revert("Recovery not possible");
     }
+
+    function transferOwnershipOnTokenContract(address newOwner) public onlyOwner override {
+        transferOwnership(newOwner);
+    }
+
+    function addAgentOnTokenContract(address agent) external override {
+        addAgent(agent);
+    }
+    function removeAgentOnTokenContract(address agent) external override {
+        removeAgent(agent);
+    }
 }

--- a/contracts/token/Token.sol
+++ b/contracts/token/Token.sol
@@ -526,9 +526,9 @@ contract Token is IToken, Context, AgentRole {
      */
     function mint(address _to, uint256 _amount) public override onlyAgent {
         require(identityRegistry.isVerified(_to), "Identity is not verified.");
-        if (compliance.created(_to, _amount)) {
-            _mint(_to, _amount);
-        }
+        require(compliance.canTransfer(msg.sender, _to, _amount), "Compliance not followed");
+        _mint(_to, _amount);
+        compliance.created(_to, _amount);
     }
 
     function batchMint(address[] calldata _toList, uint256[] calldata _amounts) external override {

--- a/contracts/token/Token.sol
+++ b/contracts/token/Token.sol
@@ -526,9 +526,9 @@ contract Token is IToken, Context, AgentRole {
      */
     function mint(address _to, uint256 _amount) public override onlyAgent {
         require(identityRegistry.isVerified(_to), "Identity is not verified.");
-		if(compliance.created(_to, _amount)) {
-			_mint(_to, _amount);
-		}
+        if(compliance.created(_to, _amount)) {
+            _mint(_to, _amount);
+        }
     }
 
     function batchMint(address[] calldata _toList, uint256[] calldata _amounts) external override {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenysolutions/t-rex",
-  "version": "2.5.0",
+  "version": "3.0.0",
   "description": "A fully compliant environment for the issuance and use of tokenized securities.",
   "main": "index.js",
   "directories": {

--- a/test/agentManager.test.js
+++ b/test/agentManager.test.js
@@ -1,0 +1,362 @@
+const Web3 = require('web3');
+require('chai')
+    .use(require('chai-as-promised'))
+    .should();
+const log = require('./helpers/logger');
+const EVMRevert = require('./helpers/VMExceptionRevert');
+
+const web3 = new Web3(new Web3.providers.HttpProvider('http://localhost:8545'));
+
+const ClaimTopicsRegistry = artifacts.require('../contracts/registry/ClaimTopicsRegistry.sol');
+const IdentityRegistry = artifacts.require('../contracts/registry/IdentityRegistry.sol');
+const TrustedIssuersRegistry = artifacts.require('../contracts/registry/TrustedIssuersRegistry.sol');
+const ClaimHolder = artifacts.require('@onchain-id/solidity/contracts/Identity.sol');
+const IssuerIdentity = artifacts.require('@onchain-id/solidity/contracts/ClaimIssuer.sol');
+const Token = artifacts.require('../contracts/token/Token.sol');
+const Compliance = artifacts.require('../contracts/compliance/DefaultCompliance.sol');
+const AgentManager = artifacts.require('../contracts/roles/AgentManager.sol');
+
+contract('Agent Manager', accounts => {
+    let claimTopicsRegistry;
+    let identityRegistry;
+    let trustedIssuersRegistry;
+    let claimIssuerContract;
+    let token;
+    let agentManager;
+    let defaultCompliance;
+    let tokenName;
+    let tokenSymbol;
+    let tokenDecimals;
+    let tokenVersion;
+    let tokenOnchainID;
+    const signer = web3.eth.accounts.create();
+    const signerKey = web3.utils.keccak256(web3.eth.abi.encodeParameter('address', signer.address));
+
+    const tokeny = accounts[0];
+    const claimIssuer = accounts[1];
+    const user1 = accounts[2];
+    const user2 = accounts[3];
+    const user3 = accounts[4];
+    const claimTopics = [1, 7, 3];
+    let user1Contract;
+    let user2Contract;
+    let user3Contract;
+    let signature3;
+    let hexedData3;
+    const agent = accounts[8];
+    let agentRole = accounts[5];
+
+    beforeEach(async () => {
+        // Tokeny deploying token
+        claimTopicsRegistry = await ClaimTopicsRegistry.new({ from: tokeny });
+        trustedIssuersRegistry = await TrustedIssuersRegistry.new({ from: tokeny });
+        defaultCompliance = await Compliance.new({ from: tokeny });
+        identityRegistry = await IdentityRegistry.new(trustedIssuersRegistry.address, claimTopicsRegistry.address, { from: tokeny });
+        tokenOnchainID = await ClaimHolder.new({ from: tokeny });
+        tokenName = 'TREXDINO';
+        tokenSymbol = 'TREX';
+        tokenDecimals = '0';
+        tokenVersion = '1.2';
+        token = await Token.new(
+            identityRegistry.address,
+            defaultCompliance.address,
+            tokenName,
+            tokenSymbol,
+            tokenDecimals,
+            tokenVersion,
+            tokenOnchainID.address,
+            { from: tokeny },
+        );
+        agentManager = await AgentManager.new(token.address, { from: agent });
+
+        await token.addAgent(agent, { from: tokeny });
+        // Tokeny adds trusted claim Topic to claim topics registry
+        await claimTopicsRegistry.addClaimTopic(7, { from: tokeny }).should.be.fulfilled;
+
+        // Claim issuer deploying identity contract
+        claimIssuerContract = await IssuerIdentity.new({ from: claimIssuer });
+
+        // Claim issuer adds claim signer key to his contract
+        await claimIssuerContract.addKey(signerKey, 3, 1, { from: claimIssuer }).should.be.fulfilled;
+
+        // Tokeny adds trusted claim Issuer to claimIssuer registry
+        await trustedIssuersRegistry.addTrustedIssuer(claimIssuerContract.address, 1, claimTopics, { from: tokeny }).should.be.fulfilled;
+
+        // user1 deploys his identity contract
+        user1Contract = await ClaimHolder.new({ from: user1 });
+
+        // user2 deploys his identity contract
+        user2Contract = await ClaimHolder.new({ from: user2 });
+
+        // identity contracts are registered in identity registry
+        await identityRegistry.addAgent(agent, { from: tokeny });
+        await identityRegistry.registerIdentity(user1, user1Contract.address, 91, {
+            from: agent,
+        }).should.be.fulfilled;
+        await identityRegistry.registerIdentity(user2, user2Contract.address, 101, {
+            from: agent,
+        }).should.be.fulfilled;
+
+        // user1 gets signature from claim issuer
+        const hexedData1 = await web3.utils.asciiToHex('Yea no, this guy is totes legit');
+        const hashedDataToSign1 = web3.utils.keccak256(
+            web3.eth.abi.encodeParameters(['address', 'uint256', 'bytes'], [user1Contract.address, 7, hexedData1]),
+        );
+
+        const signature1 = (await signer.sign(hashedDataToSign1)).signature;
+
+        // user1 adds claim to identity contract
+        await user1Contract.addClaim(7, 1, claimIssuerContract.address, signature1, hexedData1, '', { from: user1 });
+
+        // user2 gets signature from claim issuer
+        const hexedData2 = await web3.utils.asciiToHex('Yea no, this guy is totes legit');
+        const hashedDataToSign2 = web3.utils.keccak256(
+            web3.eth.abi.encodeParameters(['address', 'uint256', 'bytes'], [user2Contract.address, 7, hexedData2]),
+        );
+
+        const signature2 = (await signer.sign(hashedDataToSign2)).signature;
+
+        // user2 adds claim to identity contract
+        await user2Contract.addClaim(7, 1, claimIssuerContract.address, signature2, hexedData2, '', { from: user2 }).should.be.fulfilled;
+
+        await token.mint(user1, 1000, { from: agent });
+        await agentManager.addAgentAdmin(agent, { from: agent });
+
+    });
+
+    it('Should add admin to the role manager.', async () => {
+        let admin = accounts[6];
+        await agentManager.addAgentAdmin(admin, { from: agent });
+        (await agentManager.isAgentAdmin(admin)).should.be.equal(true);
+    });
+
+    it('Should remove admin from the role manager.', async () => {
+        await agentManager.removeAgentAdmin(agent, { from: agent });
+        (await agentManager.isAgentAdmin(agent)).should.be.equal(false);
+    });
+
+    it('Should remove supply admin from the role manager.', async () => {
+        await agentManager.addSupplyModifier(user1Contract.address, { from: agent });
+        await agentManager.removeSupplyModifier(user1Contract.address, { from: agent });
+        (await agentManager.isSupplyModifier(user1Contract.address)).should.be.equal(false);
+    });
+
+    it('Should perform minting if called by Supply modifier', async () => {
+        await agentManager.callMint(user2, 1000, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+        await agentManager.addSupplyModifier(user1Contract.address, { from: agent });
+        (await agentManager.isSupplyModifier(user1Contract.address)).should.be.equal(true);
+        await token.addAgent(agentManager.address, { from: tokeny });
+        await agentManager.callMint(user2, 1000, user1Contract.address, { from: user1 });
+    });
+
+    it('Should perform batch minting if called by Supply modifier', async () => {
+        await agentManager.callBatchMint([user1, user2], [100, 100], user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+        await agentManager.addSupplyModifier(user1Contract.address, { from: agent });
+        (await agentManager.isSupplyModifier(user1Contract.address)).should.be.equal(true);
+        await token.addAgent(agentManager.address, { from: tokeny });
+        await agentManager.callBatchMint([user1, user2], [100, 100], user1Contract.address, { from: user1 });
+    });
+
+    it('Should perform burn if called by Supply modifier', async () => {
+        await agentManager.callBurn(user1, 200, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+        await agentManager.addSupplyModifier(user1Contract.address, { from: agent });
+        (await agentManager.isSupplyModifier(user1Contract.address)).should.be.equal(true);
+        await token.addAgent(agentManager.address, { from: tokeny });
+        await agentManager.callBurn(user1, 200, user1Contract.address, { from: user1 });
+    });
+
+    it('Should perform batch burning if called by Supply modifier', async () => {
+        await agentManager.callBatchBurn([user1, user1], [100, 100], user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+        await agentManager.addSupplyModifier(user1Contract.address, { from: agent });
+        (await agentManager.isSupplyModifier(user1Contract.address)).should.be.equal(true);
+        await token.addAgent(agentManager.address, { from: tokeny });
+        await agentManager.callBatchBurn([user1, user1], [100, 100], user1Contract.address, { from: user1 });
+    });
+
+    it('Should remove freezer from the role manager.', async () => {
+        await agentManager.addFreezer(user1Contract.address, { from: agent });
+        await agentManager.removeFreezer(user1Contract.address, { from: agent });
+        (await agentManager.isFreezer(user1Contract.address)).should.be.equal(false);
+    });
+
+    it('Should remove transfer manager from the role manager.', async () => {
+        await agentManager.addTransferManager(user1Contract.address, { from: agent });
+        await agentManager.removeTransferManager(user1Contract.address, { from: agent });
+        (await agentManager.isTransferManager(user1Contract.address)).should.be.equal(false);
+    });
+
+    it('Should perform forced transfer if called by transfer manager', async () => {
+        await agentManager.callForcedTransfer(user1, user2, 200, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+        await agentManager.addTransferManager(user1Contract.address, { from: agent });
+        (await agentManager.isTransferManager(user1Contract.address)).should.be.equal(true);
+        await token.addAgent(agentManager.address, { from: tokeny });
+        await agentManager.callForcedTransfer(user1, user2, 200, user1Contract.address, { from: user1 });
+    });
+
+    it('Should perform batch forced transfer if called by transfer manager', async () => {
+        await agentManager.callBatchForcedTransfer([user1, user2], [user2, user1], [200, 100], user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+        await agentManager.addTransferManager(user1Contract.address, { from: agent });
+        (await agentManager.isTransferManager(user1Contract.address)).should.be.equal(true);
+        await token.addAgent(agentManager.address, { from: tokeny });
+        await agentManager.callBatchForcedTransfer([user1, user2], [user2, user1], [200, 100], user1Contract.address, { from: user1 });
+    });
+
+    it('Should freeze adress if called by freezer', async () => {
+        await agentManager.callSetAddressFrozen(user1, true, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+        await agentManager.addFreezer(user1Contract.address, { from: agent });
+        (await agentManager.isFreezer(user1Contract.address)).should.be.equal(true);
+        await token.addAgent(agentManager.address, { from: tokeny });
+        await agentManager.callSetAddressFrozen(user1, true, user1Contract.address, { from: user1 });
+    });
+    it('Should freeze address in batch if called by freezer', async () => {
+        await agentManager.callBatchSetAddressFrozen([user1, user2], [true, true], user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+        await agentManager.addFreezer(user1Contract.address, { from: agent });
+        (await agentManager.isFreezer(user1Contract.address)).should.be.equal(true);
+        await token.addAgent(agentManager.address, { from: tokeny });
+        await agentManager.callBatchSetAddressFrozen([user1, user2], [true, true], user1Contract.address, { from: user1 });
+    });
+    it('Should freeze tokens partially if called by freezer', async () => {
+        await agentManager.callFreezePartialTokens(user1, 200, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+        await agentManager.addFreezer(user1Contract.address, { from: agent });
+        (await agentManager.isFreezer(user1Contract.address)).should.be.equal(true);
+        await token.addAgent(agentManager.address, { from: tokeny });
+        await agentManager.callFreezePartialTokens(user1, 200, user1Contract.address, { from: user1 });
+    });
+
+    it('Should freeze partial tokens in batch if called by freezer', async () => {
+        await agentManager.callBatchFreezePartialTokens([user1, user1], [200, 100], user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+        await agentManager.addFreezer(user1Contract.address, { from: agent });
+        (await agentManager.isFreezer(user1Contract.address)).should.be.equal(true);
+        await token.addAgent(agentManager.address, { from: tokeny });
+        await agentManager.callBatchFreezePartialTokens([user1, user1], [200, 100], user1Contract.address, { from: user1 });
+    });
+
+    it('Should unfreeze tokens partially if called by freezer', async () => {
+        await agentManager.callUnfreezePartialTokens(user1, 200, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+        await agentManager.addFreezer(user1Contract.address, { from: agent });
+        (await agentManager.isFreezer(user1Contract.address)).should.be.equal(true);
+        await token.addAgent(agentManager.address, { from: tokeny });
+        await agentManager.callFreezePartialTokens(user1, 200, user1Contract.address, { from: user1 });
+        await agentManager.callUnfreezePartialTokens(user1, 200, user1Contract.address, { from: user1 });
+    });
+
+    it('Should unfreeze partial tokens in batch if called by freezer', async () => {
+        await agentManager.callBatchUnfreezePartialTokens([user1, user1], [200, 100], user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+        await agentManager.addFreezer(user1Contract.address, { from: agent });
+        (await agentManager.isFreezer(user1Contract.address)).should.be.equal(true);
+        await token.addAgent(agentManager.address, { from: tokeny });
+        await agentManager.callBatchFreezePartialTokens([user1, user1], [200, 100], user1Contract.address, { from: user1 });
+        await agentManager.callBatchUnfreezePartialTokens([user1, user1], [200, 100], user1Contract.address, { from: user1 });
+    });
+
+    it('Should pause token if called by freezer', async () => {
+        await agentManager.callPause(user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+        await agentManager.addFreezer(user1Contract.address, { from: agent });
+        (await agentManager.isFreezer(user1Contract.address)).should.be.equal(true);
+        await token.addAgent(agentManager.address, { from: tokeny });
+        await agentManager.callPause(user1Contract.address, { from: user1 });
+    });
+
+    it('Should unpause token if called by freezer', async () => {
+        await agentManager.callUnpause(user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+        await agentManager.addFreezer(user1Contract.address, { from: agent });
+        (await agentManager.isFreezer(user1Contract.address)).should.be.equal(true);
+        await token.addAgent(agentManager.address, { from: tokeny });
+        await agentManager.callPause(user1Contract.address, { from: user1 });
+        await agentManager.callUnpause(user1Contract.address, { from: user1 });
+    });
+
+    it('Should remove recovery agent from the role manager.', async () => {
+        await agentManager.addRecoveryAgent(user1Contract.address, { from: agent });
+        await agentManager.removeRecoveryAgent(user1Contract.address, { from: agent });
+        (await agentManager.isRecoveryAgent(user1Contract.address)).should.be.equal(false);
+    });
+
+    it('Should recover address if called by recovery agent', async () => {
+        // tokeny deploys a identity contract for accounts[7 ]
+        const user11Contract = await ClaimHolder.new({ from: tokeny });
+
+        // identity contracts are registered in identity registry
+        await identityRegistry.registerIdentity(accounts[7], user11Contract.address, 91, { from: agent }).should.be.fulfilled;
+
+        // user1 gets signature from claim issuer
+        const hexedData11 = await web3.utils.asciiToHex('Yea no, this guy is totes legit');
+
+        const hashedDataToSign11 = web3.utils.keccak256(
+            web3.eth.abi.encodeParameters(['address', 'uint256', 'bytes'], [user11Contract.address, 7, hexedData11]),
+        );
+
+        const signature11 = (await signer.sign(hashedDataToSign11)).signature;
+
+        // tokeny adds claim to identity contract
+        await user11Contract.addClaim(7, 1, claimIssuerContract.address, signature11, hexedData11, '', { from: tokeny });
+
+        // tokeny mint the tokens to the accounts[7]
+        await token.mint(accounts[7], 1000, { from: agent });
+
+        // tokeny add token contract as the owner of identityRegistry
+        await identityRegistry.addAgent(token.address, { from: tokeny });
+
+        // add management key of the new wallet on the onchainID
+        const key = await web3.utils.keccak256(web3.eth.abi.encodeParameter('address', accounts[8]));
+        await user11Contract.addKey(key, 1, 1, { from: tokeny });
+
+        // tokeny recover the lost wallet of accounts[7]
+        await agentManager.callRecoveryAddress(accounts[7], accounts[8], user11Contract.address, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+        await agentManager.addRecoveryAgent(user1Contract.address, { from: agent });
+        (await agentManager.isRecoveryAgent(user1Contract.address)).should.be.equal(true);
+        await token.addAgent(agentManager.address, { from: tokeny });
+        await agentManager.callRecoveryAddress(accounts[7], accounts[8], user11Contract.address, user1Contract.address, { from: user1 });
+    });
+
+    it('Should add and remove compliance agent from the role manager.', async () => {
+        await agentManager.addComplianceAgent(user1Contract.address, { from: agent });
+        await agentManager.removeComplianceAgent(user1Contract.address, { from: agent });
+        (await agentManager.isComplianceAgent(user1Contract.address)).should.be.equal(false);
+    });
+
+    it('Should remove whitelist manager from the role manager.', async () => {
+        await agentManager.addWhiteListManager(user1Contract.address, { from: agent });
+        await agentManager.removeWhiteListManager(user1Contract.address, { from: agent });
+        (await agentManager.isWhiteListManager(user1Contract.address)).should.be.equal(false);
+    });
+
+    it('Should register identity if called by whitelist manager', async () => {
+        let newUser = accounts[6];
+        let identity = await ClaimHolder.new({ from: accounts[6] });
+        await agentManager.callRegisterIdentity(newUser, identity.address, 100, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+        await agentManager.addWhiteListManager(user1Contract.address, { from: agent });
+        (await agentManager.isWhiteListManager(user1Contract.address)).should.be.equal(true);
+        await identityRegistry.addAgent(agentManager.address, { from: tokeny });
+        await agentManager.callRegisterIdentity(newUser, identity.address, 100, user1Contract.address, { from: user1 });
+    });
+
+    it('Should update identity if called by whitelist manager', async () => {
+        let newIdentity = await ClaimHolder.new({ from: user2 })
+        await agentManager.callUpdateIdentity(user2, newIdentity.address, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+        await agentManager.addWhiteListManager(user1Contract.address, { from: agent });
+        (await agentManager.isWhiteListManager(user1Contract.address)).should.be.equal(true);
+        await identityRegistry.addAgent(agentManager.address, { from: tokeny });
+        await agentManager.callUpdateIdentity(user2, newIdentity.address, user1Contract.address, { from: user1 });
+    });
+
+    it('Should update country if called by whitelist manager', async () => {
+        await agentManager.callUpdateCountry(user2, 84, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+        await agentManager.addWhiteListManager(user1Contract.address, { from: agent });
+        (await agentManager.isWhiteListManager(user1Contract.address)).should.be.equal(true);
+        await identityRegistry.addAgent(agentManager.address, { from: tokeny });
+        await agentManager.callUpdateCountry(user2, 84, user1Contract.address, { from: user1 });
+    });
+
+    it('Should delete identity if called by whitelist manager', async () => {
+        await agentManager.callDeleteIdentity(user2, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+        await agentManager.addWhiteListManager(user1Contract.address, { from: agent });
+        (await agentManager.isWhiteListManager(user1Contract.address)).should.be.equal(true);
+        await identityRegistry.addAgent(agentManager.address, { from: tokeny });
+        await agentManager.callDeleteIdentity(user2, user1Contract.address, { from: user1 });
+    });
+
+    it('Should not add or remove roles if not admin', async () => {
+        await agentManager.addWhiteListManager(user1Contract.address, { from: tokeny }).should.be.rejectedWith(EVMRevert);
+    });
+});

--- a/test/agentManager.test.js
+++ b/test/agentManager.test.js
@@ -1,5 +1,6 @@
 const Web3 = require('web3');
 require('chai')
+
   .use(require('chai-as-promised'))
   .should();
 const EVMRevert = require('./helpers/VMExceptionRevert');
@@ -16,6 +17,7 @@ const Compliance = artifacts.require('../contracts/compliance/DefaultCompliance.
 const AgentManager = artifacts.require('../contracts/roles/AgentManager.sol');
 
 contract('Agent Manager', accounts => {
+
   let claimTopicsRegistry;
   let identityRegistry;
   let trustedIssuersRegistry;

--- a/test/agentManager.test.js
+++ b/test/agentManager.test.js
@@ -208,7 +208,7 @@ contract('Agent Manager', accounts => {
     (await agentManager.isFreezer(user1Contract.address)).should.be.equal(true);
     await token.addAgent(agentManager.address, { from: tokeny });
     await agentManager.callSetAddressFrozen(user1, true, user1Contract.address, { from: user1 });
-    (await token.frozen(user1)).should.be.equal(true);
+    (await token.isFrozen(user1)).should.be.equal(true);
   });
   it('Should freeze address in batch if called by freezer', async () => {
     await agentManager
@@ -218,8 +218,8 @@ contract('Agent Manager', accounts => {
     (await agentManager.isFreezer(user1Contract.address)).should.be.equal(true);
     await token.addAgent(agentManager.address, { from: tokeny });
     await agentManager.callBatchSetAddressFrozen([user1, user2], [true, true], user1Contract.address, { from: user1 });
-    (await token.frozen(user1)).should.be.equal(true);
-    (await token.frozen(user2)).should.be.equal(true);
+    (await token.isFrozen(user1)).should.be.equal(true);
+    (await token.isFrozen(user2)).should.be.equal(true);
   });
   it('Should freeze tokens partially if called by freezer', async () => {
     await agentManager.callFreezePartialTokens(user1, 200, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
@@ -227,7 +227,7 @@ contract('Agent Manager', accounts => {
     (await agentManager.isFreezer(user1Contract.address)).should.be.equal(true);
     await token.addAgent(agentManager.address, { from: tokeny });
     await agentManager.callFreezePartialTokens(user1, 200, user1Contract.address, { from: user1 });
-    (await token.frozenTokens(user1)).toString().should.be.equal('200');
+    (await token.getFrozenTokens(user1)).toString().should.be.equal('200');
   });
 
   it('Should freeze partial tokens in batch if called by freezer', async () => {
@@ -238,7 +238,7 @@ contract('Agent Manager', accounts => {
     (await agentManager.isFreezer(user1Contract.address)).should.be.equal(true);
     await token.addAgent(agentManager.address, { from: tokeny });
     await agentManager.callBatchFreezePartialTokens([user1, user1], [200, 100], user1Contract.address, { from: user1 });
-    (await token.frozenTokens(user1)).toString().should.be.equal('300');
+    (await token.getFrozenTokens(user1)).toString().should.be.equal('300');
   });
 
   it('Should unfreeze tokens partially if called by freezer', async () => {
@@ -248,7 +248,7 @@ contract('Agent Manager', accounts => {
     await token.addAgent(agentManager.address, { from: tokeny });
     await agentManager.callFreezePartialTokens(user1, 200, user1Contract.address, { from: user1 });
     await agentManager.callUnfreezePartialTokens(user1, 200, user1Contract.address, { from: user1 });
-    (await token.frozenTokens(user1)).toString().should.be.equal('0');
+    (await token.getFrozenTokens(user1)).toString().should.be.equal('0');
   });
 
   it('Should unfreeze partial tokens in batch if called by freezer', async () => {
@@ -260,7 +260,7 @@ contract('Agent Manager', accounts => {
     await token.addAgent(agentManager.address, { from: tokeny });
     await agentManager.callBatchFreezePartialTokens([user1, user1], [200, 100], user1Contract.address, { from: user1 });
     await agentManager.callBatchUnfreezePartialTokens([user1, user1], [200, 100], user1Contract.address, { from: user1 });
-    (await token.frozenTokens(user1)).toString().should.be.equal('0');
+    (await token.getFrozenTokens(user1)).toString().should.be.equal('0');
   });
 
   it('Should pause token if called by freezer', async () => {

--- a/test/agentManager.test.js
+++ b/test/agentManager.test.js
@@ -1,6 +1,5 @@
 const Web3 = require('web3');
 require('chai')
-
   .use(require('chai-as-promised'))
   .should();
 const EVMRevert = require('./helpers/VMExceptionRevert');
@@ -17,7 +16,6 @@ const Compliance = artifacts.require('../contracts/compliance/DefaultCompliance.
 const AgentManager = artifacts.require('../contracts/roles/AgentManager.sol');
 
 contract('Agent Manager', accounts => {
-
   let claimTopicsRegistry;
   let identityRegistry;
   let trustedIssuersRegistry;
@@ -121,9 +119,9 @@ contract('Agent Manager', accounts => {
   });
 
   it('Should add admin to the role manager.', async () => {
-    let admin = accounts[6];
-    await agentManager.addAgentAdmin(admin, { from: agent });
-    (await agentManager.isAgentAdmin(admin)).should.be.equal(true);
+    const adminRole = accounts[6];
+    await agentManager.addAgentAdmin(adminRole, { from: agent });
+    (await agentManager.isAgentAdmin(adminRole)).should.be.equal(true);
   });
 
   it('Should remove admin from the role manager.', async () => {
@@ -350,8 +348,8 @@ contract('Agent Manager', accounts => {
   });
 
   it('Should register identity if called by whitelist manager', async () => {
-    let newUser = accounts[6];
-    let identity = await ClaimHolder.new({ from: accounts[6] });
+    const newUser = accounts[6];
+    const identity = await ClaimHolder.new({ from: accounts[6] });
     await agentManager.callRegisterIdentity(newUser, identity.address, 100, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
     await agentManager.addWhiteListManager(user1Contract.address, { from: admin });
     (await agentManager.isWhiteListManager(user1Contract.address)).should.be.equal(true);
@@ -362,7 +360,7 @@ contract('Agent Manager', accounts => {
   });
 
   it('Should update identity if called by whitelist manager', async () => {
-    let newIdentity = await ClaimHolder.new({ from: user2 });
+    const newIdentity = await ClaimHolder.new({ from: user2 });
     await agentManager.callUpdateIdentity(user2, newIdentity.address, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
     await agentManager.addWhiteListManager(user1Contract.address, { from: admin });
     (await agentManager.isWhiteListManager(user1Contract.address)).should.be.equal(true);

--- a/test/agentManager.test.js
+++ b/test/agentManager.test.js
@@ -1,7 +1,7 @@
 const Web3 = require('web3');
 require('chai')
-    .use(require('chai-as-promised'))
-    .should();
+  .use(require('chai-as-promised'))
+  .should();
 const EVMRevert = require('./helpers/VMExceptionRevert');
 
 const web3 = new Web3(new Web3.providers.HttpProvider('http://localhost:8545'));
@@ -16,378 +16,388 @@ const Compliance = artifacts.require('../contracts/compliance/DefaultCompliance.
 const AgentManager = artifacts.require('../contracts/roles/AgentManager.sol');
 
 contract('Agent Manager', accounts => {
-    let claimTopicsRegistry;
-    let identityRegistry;
-    let trustedIssuersRegistry;
-    let claimIssuerContract;
-    let token;
-    let agentManager;
-    let defaultCompliance;
-    let tokenName;
-    let tokenSymbol;
-    let tokenDecimals;
-    let tokenVersion;
-    let tokenOnchainID;
-    const signer = web3.eth.accounts.create();
-    const signerKey = web3.utils.keccak256(web3.eth.abi.encodeParameter('address', signer.address));
+  let claimTopicsRegistry;
+  let identityRegistry;
+  let trustedIssuersRegistry;
+  let claimIssuerContract;
+  let token;
+  let agentManager;
+  let defaultCompliance;
+  let tokenName;
+  let tokenSymbol;
+  let tokenDecimals;
+  let tokenVersion;
+  let tokenOnchainID;
+  const signer = web3.eth.accounts.create();
+  const signerKey = web3.utils.keccak256(web3.eth.abi.encodeParameter('address', signer.address));
 
-    const tokeny = accounts[0];
-    const claimIssuer = accounts[1];
-    const user1 = accounts[2];
-	const user2 = accounts[3];
-    const claimTopics = [1, 7, 3];
-    let user1Contract;
-    let user2Contract;
-	const agent = accounts[8];
-	const admin = accounts[4];
+  const tokeny = accounts[0];
+  const claimIssuer = accounts[1];
+  const user1 = accounts[2];
+  const user2 = accounts[3];
+  const claimTopics = [1, 7, 3];
+  let user1Contract;
+  let user2Contract;
+  const agent = accounts[8];
+  const admin = accounts[4];
 
-    beforeEach(async () => {
-        // Tokeny deploying token
-        claimTopicsRegistry = await ClaimTopicsRegistry.new({ from: tokeny });
-        trustedIssuersRegistry = await TrustedIssuersRegistry.new({ from: tokeny });
-        defaultCompliance = await Compliance.new({ from: tokeny });
-        identityRegistry = await IdentityRegistry.new(trustedIssuersRegistry.address, claimTopicsRegistry.address, { from: tokeny });
-        tokenOnchainID = await ClaimHolder.new({ from: tokeny });
-        tokenName = 'TREXDINO';
-        tokenSymbol = 'TREX';
-        tokenDecimals = '0';
-        tokenVersion = '1.2';
-        token = await Token.new(
-            identityRegistry.address,
-            defaultCompliance.address,
-            tokenName,
-            tokenSymbol,
-            tokenDecimals,
-            tokenVersion,
-            tokenOnchainID.address,
-            { from: tokeny },
-        );
-        agentManager = await AgentManager.new(token.address, { from: agent });
+  beforeEach(async () => {
+    // Tokeny deploying token
+    claimTopicsRegistry = await ClaimTopicsRegistry.new({ from: tokeny });
+    trustedIssuersRegistry = await TrustedIssuersRegistry.new({ from: tokeny });
+    defaultCompliance = await Compliance.new({ from: tokeny });
+    identityRegistry = await IdentityRegistry.new(trustedIssuersRegistry.address, claimTopicsRegistry.address, { from: tokeny });
+    tokenOnchainID = await ClaimHolder.new({ from: tokeny });
+    tokenName = 'TREXDINO';
+    tokenSymbol = 'TREX';
+    tokenDecimals = '0';
+    tokenVersion = '1.2';
+    token = await Token.new(
+      identityRegistry.address,
+      defaultCompliance.address,
+      tokenName,
+      tokenSymbol,
+      tokenDecimals,
+      tokenVersion,
+      tokenOnchainID.address,
+      { from: tokeny },
+    );
+    agentManager = await AgentManager.new(token.address, { from: agent });
 
-        await token.addAgent(agent, { from: tokeny });
-        // Tokeny adds trusted claim Topic to claim topics registry
-        await claimTopicsRegistry.addClaimTopic(7, { from: tokeny }).should.be.fulfilled;
+    await token.addAgent(agent, { from: tokeny });
+    // Tokeny adds trusted claim Topic to claim topics registry
+    await claimTopicsRegistry.addClaimTopic(7, { from: tokeny }).should.be.fulfilled;
 
-        // Claim issuer deploying identity contract
-        claimIssuerContract = await IssuerIdentity.new({ from: claimIssuer });
+    // Claim issuer deploying identity contract
+    claimIssuerContract = await IssuerIdentity.new({ from: claimIssuer });
 
-        // Claim issuer adds claim signer key to his contract
-        await claimIssuerContract.addKey(signerKey, 3, 1, { from: claimIssuer }).should.be.fulfilled;
+    // Claim issuer adds claim signer key to his contract
+    await claimIssuerContract.addKey(signerKey, 3, 1, { from: claimIssuer }).should.be.fulfilled;
 
-        // Tokeny adds trusted claim Issuer to claimIssuer registry
-        await trustedIssuersRegistry.addTrustedIssuer(claimIssuerContract.address, 1, claimTopics, { from: tokeny }).should.be.fulfilled;
+    // Tokeny adds trusted claim Issuer to claimIssuer registry
+    await trustedIssuersRegistry.addTrustedIssuer(claimIssuerContract.address, 1, claimTopics, { from: tokeny }).should.be.fulfilled;
 
-        // user1 deploys his identity contract
-        user1Contract = await ClaimHolder.new({ from: user1 });
+    // user1 deploys his identity contract
+    user1Contract = await ClaimHolder.new({ from: user1 });
 
-        // user2 deploys his identity contract
-        user2Contract = await ClaimHolder.new({ from: user2 });
+    // user2 deploys his identity contract
+    user2Contract = await ClaimHolder.new({ from: user2 });
 
-        // identity contracts are registered in identity registry
-        await identityRegistry.addAgent(agent, { from: tokeny });
-        await identityRegistry.registerIdentity(user1, user1Contract.address, 91, {
-            from: agent,
-        }).should.be.fulfilled;
-        await identityRegistry.registerIdentity(user2, user2Contract.address, 101, {
-            from: agent,
-        }).should.be.fulfilled;
+    // identity contracts are registered in identity registry
+    await identityRegistry.addAgent(agent, { from: tokeny });
+    await identityRegistry.registerIdentity(user1, user1Contract.address, 91, {
+      from: agent,
+    }).should.be.fulfilled;
+    await identityRegistry.registerIdentity(user2, user2Contract.address, 101, {
+      from: agent,
+    }).should.be.fulfilled;
 
-        // user1 gets signature from claim issuer
-        const hexedData1 = await web3.utils.asciiToHex('Yea no, this guy is totes legit');
-        const hashedDataToSign1 = web3.utils.keccak256(
-            web3.eth.abi.encodeParameters(['address', 'uint256', 'bytes'], [user1Contract.address, 7, hexedData1]),
-        );
+    // user1 gets signature from claim issuer
+    const hexedData1 = await web3.utils.asciiToHex('Yea no, this guy is totes legit');
+    const hashedDataToSign1 = web3.utils.keccak256(
+      web3.eth.abi.encodeParameters(['address', 'uint256', 'bytes'], [user1Contract.address, 7, hexedData1]),
+    );
 
-        const signature1 = (await signer.sign(hashedDataToSign1)).signature;
+    const signature1 = (await signer.sign(hashedDataToSign1)).signature;
 
-        // user1 adds claim to identity contract
-        await user1Contract.addClaim(7, 1, claimIssuerContract.address, signature1, hexedData1, '', { from: user1 });
+    // user1 adds claim to identity contract
+    await user1Contract.addClaim(7, 1, claimIssuerContract.address, signature1, hexedData1, '', { from: user1 });
 
-        // user2 gets signature from claim issuer
-        const hexedData2 = await web3.utils.asciiToHex('Yea no, this guy is totes legit');
-        const hashedDataToSign2 = web3.utils.keccak256(
-            web3.eth.abi.encodeParameters(['address', 'uint256', 'bytes'], [user2Contract.address, 7, hexedData2]),
-        );
+    // user2 gets signature from claim issuer
+    const hexedData2 = await web3.utils.asciiToHex('Yea no, this guy is totes legit');
+    const hashedDataToSign2 = web3.utils.keccak256(
+      web3.eth.abi.encodeParameters(['address', 'uint256', 'bytes'], [user2Contract.address, 7, hexedData2]),
+    );
 
-        const signature2 = (await signer.sign(hashedDataToSign2)).signature;
+    const signature2 = (await signer.sign(hashedDataToSign2)).signature;
 
-        // user2 adds claim to identity contract
-        await user2Contract.addClaim(7, 1, claimIssuerContract.address, signature2, hexedData2, '', { from: user2 }).should.be.fulfilled;
+    // user2 adds claim to identity contract
+    await user2Contract.addClaim(7, 1, claimIssuerContract.address, signature2, hexedData2, '', { from: user2 }).should.be.fulfilled;
 
-        await token.mint(user1, 1000, { from: agent });
-        await agentManager.addAgentAdmin(admin, { from: agent });
+    await token.mint(user1, 1000, { from: agent });
+    await agentManager.addAgentAdmin(admin, { from: agent });
+  });
 
-    });
+  it('Should add admin to the role manager.', async () => {
+    let admin = accounts[6];
+    await agentManager.addAgentAdmin(admin, { from: agent });
+    (await agentManager.isAgentAdmin(admin)).should.be.equal(true);
+  });
 
-    it('Should add admin to the role manager.', async () => {
-        let admin = accounts[6];
-        await agentManager.addAgentAdmin(admin, { from: agent });
-        (await agentManager.isAgentAdmin(admin)).should.be.equal(true);
-    });
+  it('Should remove admin from the role manager.', async () => {
+    await agentManager.removeAgentAdmin(admin, { from: agent });
+    (await agentManager.isAgentAdmin(admin)).should.be.equal(false);
+  });
 
-    it('Should remove admin from the role manager.', async () => {
-        await agentManager.removeAgentAdmin(admin, { from: agent });
-        (await agentManager.isAgentAdmin(admin)).should.be.equal(false);
-    });
+  it('Should perform minting if called by Supply modifier', async () => {
+    await agentManager.callMint(user2, 1000, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    await agentManager.addSupplyModifier(user1Contract.address, { from: admin });
+    (await agentManager.isSupplyModifier(user1Contract.address)).should.be.equal(true);
+    await token.addAgent(agentManager.address, { from: tokeny });
+    await agentManager.callMint(user2, 1000, user1Contract.address, { from: user1 });
+    (await token.balanceOf(user2)).toString().should.be.equal('1000');
+  });
 
-    it('Should perform minting if called by Supply modifier', async () => {
-        await agentManager.callMint(user2, 1000, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
-        await agentManager.addSupplyModifier(user1Contract.address, { from: admin });
-        (await agentManager.isSupplyModifier(user1Contract.address)).should.be.equal(true);
-        await token.addAgent(agentManager.address, { from: tokeny });
-		await agentManager.callMint(user2, 1000, user1Contract.address, { from: user1 });
-		(await token.balanceOf(user2)).toString().should.be.equal('1000');
-    });
+  it('Should perform batch minting if called by Supply modifier', async () => {
+    await agentManager.callBatchMint([user1, user2], [100, 100], user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    await agentManager.addSupplyModifier(user1Contract.address, { from: admin });
+    (await agentManager.isSupplyModifier(user1Contract.address)).should.be.equal(true);
+    await token.addAgent(agentManager.address, { from: tokeny });
+    await agentManager.callBatchMint([user1, user2], [100, 100], user1Contract.address, { from: user1 });
+    (await token.balanceOf(user1)).toString().should.be.equal('1100');
+    (await token.balanceOf(user2)).toString().should.be.equal('100');
+  });
 
-    it('Should perform batch minting if called by Supply modifier', async () => {
-        await agentManager.callBatchMint([user1, user2], [100, 100], user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
-        await agentManager.addSupplyModifier(user1Contract.address, { from: admin });
-        (await agentManager.isSupplyModifier(user1Contract.address)).should.be.equal(true);
-        await token.addAgent(agentManager.address, { from: tokeny });
-		await agentManager.callBatchMint([user1, user2], [100, 100], user1Contract.address, { from: user1 });
-		(await token.balanceOf(user1)).toString().should.be.equal('1100');
-		(await token.balanceOf(user2)).toString().should.be.equal('100');
-    });
+  it('Should perform burn if called by Supply modifier', async () => {
+    await agentManager.callBurn(user1, 200, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    await agentManager.addSupplyModifier(user1Contract.address, { from: admin });
+    (await agentManager.isSupplyModifier(user1Contract.address)).should.be.equal(true);
+    await token.addAgent(agentManager.address, { from: tokeny });
+    await agentManager.callBurn(user1, 200, user1Contract.address, { from: user1 });
+    (await token.balanceOf(user1)).toString().should.be.equal('800');
+  });
 
-    it('Should perform burn if called by Supply modifier', async () => {
-        await agentManager.callBurn(user1, 200, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
-        await agentManager.addSupplyModifier(user1Contract.address, { from: admin });
-        (await agentManager.isSupplyModifier(user1Contract.address)).should.be.equal(true);
-        await token.addAgent(agentManager.address, { from: tokeny });
-		await agentManager.callBurn(user1, 200, user1Contract.address, { from: user1 });
-		(await token.balanceOf(user1)).toString().should.be.equal('800');
-    });
+  it('Should perform batch burning if called by Supply modifier', async () => {
+    await agentManager.callBatchBurn([user1, user1], [100, 100], user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    await agentManager.addSupplyModifier(user1Contract.address, { from: admin });
+    (await agentManager.isSupplyModifier(user1Contract.address)).should.be.equal(true);
+    await token.addAgent(agentManager.address, { from: tokeny });
+    await agentManager.callMint(user2, 1000, user1Contract.address, { from: user1 });
+    await agentManager.callBatchBurn([user1, user2], [100, 100], user1Contract.address, { from: user1 });
+    (await token.balanceOf(user1)).toString().should.be.equal('900');
+    (await token.balanceOf(user2)).toString().should.be.equal('900');
+  });
 
-    it('Should perform batch burning if called by Supply modifier', async () => {
-        await agentManager.callBatchBurn([user1, user1], [100, 100], user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
-        await agentManager.addSupplyModifier(user1Contract.address, { from: admin });
-        (await agentManager.isSupplyModifier(user1Contract.address)).should.be.equal(true);
-		await token.addAgent(agentManager.address, { from: tokeny });
-		await agentManager.callMint(user2, 1000, user1Contract.address, { from: user1 });
-		await agentManager.callBatchBurn([user1, user2], [100, 100], user1Contract.address, { from: user1 });
-		(await token.balanceOf(user1)).toString().should.be.equal('900');
-		(await token.balanceOf(user2)).toString().should.be.equal('900');
-	});
-	
-	it('Should remove supply admin from the role manager.', async () => {
-        await agentManager.addSupplyModifier(user1Contract.address, { from: admin });
-        await agentManager.removeSupplyModifier(user1Contract.address, { from: admin });
-        (await agentManager.isSupplyModifier(user1Contract.address)).should.be.equal(false);
-    });
+  it('Should remove supply admin from the role manager.', async () => {
+    await agentManager.addSupplyModifier(user1Contract.address, { from: admin });
+    await agentManager.removeSupplyModifier(user1Contract.address, { from: admin });
+    (await agentManager.isSupplyModifier(user1Contract.address)).should.be.equal(false);
+  });
 
-    it('Should perform forced transfer if called by transfer manager', async () => {
-        await agentManager.callForcedTransfer(user1, user2, 200, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
-        await agentManager.addTransferManager(user1Contract.address, { from: admin });
-        (await agentManager.isTransferManager(user1Contract.address)).should.be.equal(true);
-        await token.addAgent(agentManager.address, { from: tokeny });
-		await agentManager.callForcedTransfer(user1, user2, 200, user1Contract.address, { from: user1 });
-		(await token.balanceOf(user1)).toString().should.be.equal('800');
-		(await token.balanceOf(user2)).toString().should.be.equal('200');
-    });
+  it('Should perform forced transfer if called by transfer manager', async () => {
+    await agentManager.callForcedTransfer(user1, user2, 200, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    await agentManager.addTransferManager(user1Contract.address, { from: admin });
+    (await agentManager.isTransferManager(user1Contract.address)).should.be.equal(true);
+    await token.addAgent(agentManager.address, { from: tokeny });
+    await agentManager.callForcedTransfer(user1, user2, 200, user1Contract.address, { from: user1 });
+    (await token.balanceOf(user1)).toString().should.be.equal('800');
+    (await token.balanceOf(user2)).toString().should.be.equal('200');
+  });
 
-    it('Should perform batch forced transfer if called by transfer manager', async () => {
-        await agentManager.callBatchForcedTransfer([user1, user2], [user2, user1], [200, 100], user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
-        await agentManager.addTransferManager(user1Contract.address, { from: admin });
-        (await agentManager.isTransferManager(user1Contract.address)).should.be.equal(true);
-        await token.addAgent(agentManager.address, { from: tokeny });
-		await agentManager.callBatchForcedTransfer([user1, user2], [user2, user1], [200, 100], user1Contract.address, { from: user1 });
-		(await token.balanceOf(user1)).toString().should.be.equal('900');
-		(await token.balanceOf(user2)).toString().should.be.equal('100');
-	});
-	
-	it('Should remove transfer manager from the role manager.', async () => {
-        await agentManager.addTransferManager(user1Contract.address, { from: admin });
-        await agentManager.removeTransferManager(user1Contract.address, { from: admin });
-        (await agentManager.isTransferManager(user1Contract.address)).should.be.equal(false);
-    });
+  it('Should perform batch forced transfer if called by transfer manager', async () => {
+    await agentManager
+      .callBatchForcedTransfer([user1, user2], [user2, user1], [200, 100], user1Contract.address, { from: user1 })
+      .should.be.rejectedWith(EVMRevert);
+    await agentManager.addTransferManager(user1Contract.address, { from: admin });
+    (await agentManager.isTransferManager(user1Contract.address)).should.be.equal(true);
+    await token.addAgent(agentManager.address, { from: tokeny });
+    await agentManager.callBatchForcedTransfer([user1, user2], [user2, user1], [200, 100], user1Contract.address, { from: user1 });
+    (await token.balanceOf(user1)).toString().should.be.equal('900');
+    (await token.balanceOf(user2)).toString().should.be.equal('100');
+  });
 
-    it('Should freeze adress if called by freezer', async () => {
-        await agentManager.callSetAddressFrozen(user1, true, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
-        await agentManager.addFreezer(user1Contract.address, { from: admin });
-        (await agentManager.isFreezer(user1Contract.address)).should.be.equal(true);
-        await token.addAgent(agentManager.address, { from: tokeny });
-		await agentManager.callSetAddressFrozen(user1, true, user1Contract.address, { from: user1 });
-		(await token.frozen(user1)).should.be.equal(true);
-    });
-    it('Should freeze address in batch if called by freezer', async () => {
-        await agentManager.callBatchSetAddressFrozen([user1, user2], [true, true], user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
-        await agentManager.addFreezer(user1Contract.address, { from: admin });
-        (await agentManager.isFreezer(user1Contract.address)).should.be.equal(true);
-        await token.addAgent(agentManager.address, { from: tokeny });
-		await agentManager.callBatchSetAddressFrozen([user1, user2], [true, true], user1Contract.address, { from: user1 });
-		(await token.frozen(user1)).should.be.equal(true);
-		(await token.frozen(user2)).should.be.equal(true);
-    });
-    it('Should freeze tokens partially if called by freezer', async () => {
-        await agentManager.callFreezePartialTokens(user1, 200, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
-        await agentManager.addFreezer(user1Contract.address, { from: admin });
-        (await agentManager.isFreezer(user1Contract.address)).should.be.equal(true);
-        await token.addAgent(agentManager.address, { from: tokeny });
-		await agentManager.callFreezePartialTokens(user1, 200, user1Contract.address, { from: user1 });
-		(await token.frozenTokens(user1)).toString().should.be.equal('200');
-    });
+  it('Should remove transfer manager from the role manager.', async () => {
+    await agentManager.addTransferManager(user1Contract.address, { from: admin });
+    await agentManager.removeTransferManager(user1Contract.address, { from: admin });
+    (await agentManager.isTransferManager(user1Contract.address)).should.be.equal(false);
+  });
 
-    it('Should freeze partial tokens in batch if called by freezer', async () => {
-        await agentManager.callBatchFreezePartialTokens([user1, user1], [200, 100], user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
-        await agentManager.addFreezer(user1Contract.address, { from: admin });
-        (await agentManager.isFreezer(user1Contract.address)).should.be.equal(true);
-        await token.addAgent(agentManager.address, { from: tokeny });
-		await agentManager.callBatchFreezePartialTokens([user1, user1], [200, 100], user1Contract.address, { from: user1 });
-		(await token.frozenTokens(user1)).toString().should.be.equal('300');
-    });
+  it('Should freeze adress if called by freezer', async () => {
+    await agentManager.callSetAddressFrozen(user1, true, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    await agentManager.addFreezer(user1Contract.address, { from: admin });
+    (await agentManager.isFreezer(user1Contract.address)).should.be.equal(true);
+    await token.addAgent(agentManager.address, { from: tokeny });
+    await agentManager.callSetAddressFrozen(user1, true, user1Contract.address, { from: user1 });
+    (await token.frozen(user1)).should.be.equal(true);
+  });
+  it('Should freeze address in batch if called by freezer', async () => {
+    await agentManager
+      .callBatchSetAddressFrozen([user1, user2], [true, true], user1Contract.address, { from: user1 })
+      .should.be.rejectedWith(EVMRevert);
+    await agentManager.addFreezer(user1Contract.address, { from: admin });
+    (await agentManager.isFreezer(user1Contract.address)).should.be.equal(true);
+    await token.addAgent(agentManager.address, { from: tokeny });
+    await agentManager.callBatchSetAddressFrozen([user1, user2], [true, true], user1Contract.address, { from: user1 });
+    (await token.frozen(user1)).should.be.equal(true);
+    (await token.frozen(user2)).should.be.equal(true);
+  });
+  it('Should freeze tokens partially if called by freezer', async () => {
+    await agentManager.callFreezePartialTokens(user1, 200, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    await agentManager.addFreezer(user1Contract.address, { from: admin });
+    (await agentManager.isFreezer(user1Contract.address)).should.be.equal(true);
+    await token.addAgent(agentManager.address, { from: tokeny });
+    await agentManager.callFreezePartialTokens(user1, 200, user1Contract.address, { from: user1 });
+    (await token.frozenTokens(user1)).toString().should.be.equal('200');
+  });
 
-    it('Should unfreeze tokens partially if called by freezer', async () => {
-        await agentManager.callUnfreezePartialTokens(user1, 200, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
-        await agentManager.addFreezer(user1Contract.address, { from: admin });
-        (await agentManager.isFreezer(user1Contract.address)).should.be.equal(true);
-        await token.addAgent(agentManager.address, { from: tokeny });
-        await agentManager.callFreezePartialTokens(user1, 200, user1Contract.address, { from: user1 });
-		await agentManager.callUnfreezePartialTokens(user1, 200, user1Contract.address, { from: user1 });
-		(await token.frozenTokens(user1)).toString().should.be.equal('0');
-    });
+  it('Should freeze partial tokens in batch if called by freezer', async () => {
+    await agentManager
+      .callBatchFreezePartialTokens([user1, user1], [200, 100], user1Contract.address, { from: user1 })
+      .should.be.rejectedWith(EVMRevert);
+    await agentManager.addFreezer(user1Contract.address, { from: admin });
+    (await agentManager.isFreezer(user1Contract.address)).should.be.equal(true);
+    await token.addAgent(agentManager.address, { from: tokeny });
+    await agentManager.callBatchFreezePartialTokens([user1, user1], [200, 100], user1Contract.address, { from: user1 });
+    (await token.frozenTokens(user1)).toString().should.be.equal('300');
+  });
 
-    it('Should unfreeze partial tokens in batch if called by freezer', async () => {
-        await agentManager.callBatchUnfreezePartialTokens([user1, user1], [200, 100], user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
-        await agentManager.addFreezer(user1Contract.address, { from: admin });
-        (await agentManager.isFreezer(user1Contract.address)).should.be.equal(true);
-        await token.addAgent(agentManager.address, { from: tokeny });
-        await agentManager.callBatchFreezePartialTokens([user1, user1], [200, 100], user1Contract.address, { from: user1 });
-		await agentManager.callBatchUnfreezePartialTokens([user1, user1], [200, 100], user1Contract.address, { from: user1 });
-		(await token.frozenTokens(user1)).toString().should.be.equal('0');
-    });
+  it('Should unfreeze tokens partially if called by freezer', async () => {
+    await agentManager.callUnfreezePartialTokens(user1, 200, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    await agentManager.addFreezer(user1Contract.address, { from: admin });
+    (await agentManager.isFreezer(user1Contract.address)).should.be.equal(true);
+    await token.addAgent(agentManager.address, { from: tokeny });
+    await agentManager.callFreezePartialTokens(user1, 200, user1Contract.address, { from: user1 });
+    await agentManager.callUnfreezePartialTokens(user1, 200, user1Contract.address, { from: user1 });
+    (await token.frozenTokens(user1)).toString().should.be.equal('0');
+  });
 
-    it('Should pause token if called by freezer', async () => {
-        await agentManager.callPause(user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
-        await agentManager.addFreezer(user1Contract.address, { from: admin });
-        (await agentManager.isFreezer(user1Contract.address)).should.be.equal(true);
-        await token.addAgent(agentManager.address, { from: tokeny });
-		await agentManager.callPause(user1Contract.address, { from: user1 });
-		(await token.paused()).should.be.equal(true);
-    });
+  it('Should unfreeze partial tokens in batch if called by freezer', async () => {
+    await agentManager
+      .callBatchUnfreezePartialTokens([user1, user1], [200, 100], user1Contract.address, { from: user1 })
+      .should.be.rejectedWith(EVMRevert);
+    await agentManager.addFreezer(user1Contract.address, { from: admin });
+    (await agentManager.isFreezer(user1Contract.address)).should.be.equal(true);
+    await token.addAgent(agentManager.address, { from: tokeny });
+    await agentManager.callBatchFreezePartialTokens([user1, user1], [200, 100], user1Contract.address, { from: user1 });
+    await agentManager.callBatchUnfreezePartialTokens([user1, user1], [200, 100], user1Contract.address, { from: user1 });
+    (await token.frozenTokens(user1)).toString().should.be.equal('0');
+  });
 
-    it('Should unpause token if called by freezer', async () => {
-        await agentManager.callUnpause(user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
-        await agentManager.addFreezer(user1Contract.address, { from: admin });
-        (await agentManager.isFreezer(user1Contract.address)).should.be.equal(true);
-        await token.addAgent(agentManager.address, { from: tokeny });
-        await agentManager.callPause(user1Contract.address, { from: user1 });
-		await agentManager.callUnpause(user1Contract.address, { from: user1 });
-		(await token.paused()).should.be.equal(false);
-	});
-	
-	it('Should remove freezer from the role manager.', async () => {
-        await agentManager.addFreezer(user1Contract.address, { from: admin });
-        await agentManager.removeFreezer(user1Contract.address, { from: admin });
-        (await agentManager.isFreezer(user1Contract.address)).should.be.equal(false);
-    });
+  it('Should pause token if called by freezer', async () => {
+    await agentManager.callPause(user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    await agentManager.addFreezer(user1Contract.address, { from: admin });
+    (await agentManager.isFreezer(user1Contract.address)).should.be.equal(true);
+    await token.addAgent(agentManager.address, { from: tokeny });
+    await agentManager.callPause(user1Contract.address, { from: user1 });
+    (await token.paused()).should.be.equal(true);
+  });
 
-    it('Should recover address if called by recovery agent', async () => {
-		const user = accounts[7];
+  it('Should unpause token if called by freezer', async () => {
+    await agentManager.callUnpause(user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    await agentManager.addFreezer(user1Contract.address, { from: admin });
+    (await agentManager.isFreezer(user1Contract.address)).should.be.equal(true);
+    await token.addAgent(agentManager.address, { from: tokeny });
+    await agentManager.callPause(user1Contract.address, { from: user1 });
+    await agentManager.callUnpause(user1Contract.address, { from: user1 });
+    (await token.paused()).should.be.equal(false);
+  });
 
-        // tokeny deploys a identity contract for user
-        const userContract = await ClaimHolder.new({ from: tokeny });
+  it('Should remove freezer from the role manager.', async () => {
+    await agentManager.addFreezer(user1Contract.address, { from: admin });
+    await agentManager.removeFreezer(user1Contract.address, { from: admin });
+    (await agentManager.isFreezer(user1Contract.address)).should.be.equal(false);
+  });
 
-        // identity contracts are registered in identity registry
-        await identityRegistry.registerIdentity(user, userContract.address, 91, { from: agent }).should.be.fulfilled;
+  it('Should recover address if called by recovery agent', async () => {
+    const user = accounts[7];
 
-        // user gets signature from claim issuer
-        const hexedData = await web3.utils.asciiToHex('Yea no, this guy is totes legit');
+    // tokeny deploys a identity contract for user
+    const userContract = await ClaimHolder.new({ from: tokeny });
 
-        const hashedDataToSign = web3.utils.keccak256(
-            web3.eth.abi.encodeParameters(['address', 'uint256', 'bytes'], [userContract.address, 7, hexedData]),
-        );
+    // identity contracts are registered in identity registry
+    await identityRegistry.registerIdentity(user, userContract.address, 91, { from: agent }).should.be.fulfilled;
 
-        const signature = (await signer.sign(hashedDataToSign)).signature;
+    // user gets signature from claim issuer
+    const hexedData = await web3.utils.asciiToHex('Yea no, this guy is totes legit');
 
-        // tokeny adds claim to identity contract
-        await userContract.addClaim(7, 1, claimIssuerContract.address, signature, hexedData, '', { from: tokeny });
+    const hashedDataToSign = web3.utils.keccak256(
+      web3.eth.abi.encodeParameters(['address', 'uint256', 'bytes'], [userContract.address, 7, hexedData]),
+    );
 
-        // tokeny mint the tokens to the accounts[7]
-        await token.mint(user, 1000, { from: agent });
+    const signature = (await signer.sign(hashedDataToSign)).signature;
 
-        // tokeny add token contract as the owner of identityRegistry
-        await identityRegistry.addAgent(token.address, { from: tokeny });
+    // tokeny adds claim to identity contract
+    await userContract.addClaim(7, 1, claimIssuerContract.address, signature, hexedData, '', { from: tokeny });
 
-        // add management key of the new wallet on the onchainID
-        const key = await web3.utils.keccak256(web3.eth.abi.encodeParameter('address', accounts[8]));
-        await userContract.addKey(key, 1, 1, { from: tokeny });
+    // tokeny mint the tokens to the accounts[7]
+    await token.mint(user, 1000, { from: agent });
 
-		const newWallet = accounts[8];
-        // tokeny recover the lost wallet of accounts[7]
-        await agentManager.callRecoveryAddress(user, newWallet, userContract.address, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
-        await agentManager.addRecoveryAgent(user1Contract.address, { from: admin });
-        (await agentManager.isRecoveryAgent(user1Contract.address)).should.be.equal(true);
-        await token.addAgent(agentManager.address, { from: tokeny });
-	    await agentManager.callRecoveryAddress(user, newWallet, userContract.address, user1Contract.address, { from: user1 });
-	    const balance1 = await token.balanceOf(user);
-	    const balance2 = await token.balanceOf(newWallet);
-	    balance1.toString().should.equal('0');
-	    balance2.toString().should.equal('1000');
-	});
-	
-	it('Should remove recovery agent from the role manager.', async () => {
-        await agentManager.addRecoveryAgent(user1Contract.address, { from: admin });
-        await agentManager.removeRecoveryAgent(user1Contract.address, { from: admin });
-        (await agentManager.isRecoveryAgent(user1Contract.address)).should.be.equal(false);
-    });
+    // tokeny add token contract as the owner of identityRegistry
+    await identityRegistry.addAgent(token.address, { from: tokeny });
 
-    it('Should add and remove compliance agent from the role manager.', async () => {
-	    await agentManager.addComplianceAgent(user1Contract.address, { from: admin });
-	    (await agentManager.isComplianceAgent(user1Contract.address)).should.be.equal(true);
-        await agentManager.removeComplianceAgent(user1Contract.address, { from: admin });
-        (await agentManager.isComplianceAgent(user1Contract.address)).should.be.equal(false);
-    });
+    // add management key of the new wallet on the onchainID
+    const key = await web3.utils.keccak256(web3.eth.abi.encodeParameter('address', accounts[8]));
+    await userContract.addKey(key, 1, 1, { from: tokeny });
 
-    it('Should register identity if called by whitelist manager', async () => {
-        let newUser = accounts[6];
-        let identity = await ClaimHolder.new({ from: accounts[6] });
-        await agentManager.callRegisterIdentity(newUser, identity.address, 100, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
-        await agentManager.addWhiteListManager(user1Contract.address, { from: admin });
-        (await agentManager.isWhiteListManager(user1Contract.address)).should.be.equal(true);
-        await identityRegistry.addAgent(agentManager.address, { from: tokeny });
-	    await agentManager.callRegisterIdentity(newUser, identity.address, 100, user1Contract.address, { from: user1 });
-	    const registered = await identityRegistry.contains(newUser);
-	    registered.toString().should.equal('true');
-    });
+    const newWallet = accounts[8];
+    // tokeny recover the lost wallet of accounts[7]
+    await agentManager
+      .callRecoveryAddress(user, newWallet, userContract.address, user1Contract.address, { from: user1 })
+      .should.be.rejectedWith(EVMRevert);
+    await agentManager.addRecoveryAgent(user1Contract.address, { from: admin });
+    (await agentManager.isRecoveryAgent(user1Contract.address)).should.be.equal(true);
+    await token.addAgent(agentManager.address, { from: tokeny });
+    await agentManager.callRecoveryAddress(user, newWallet, userContract.address, user1Contract.address, { from: user1 });
+    const balance1 = await token.balanceOf(user);
+    const balance2 = await token.balanceOf(newWallet);
+    balance1.toString().should.equal('0');
+    balance2.toString().should.equal('1000');
+  });
 
-    it('Should update identity if called by whitelist manager', async () => {
-        let newIdentity = await ClaimHolder.new({ from: user2 })
-        await agentManager.callUpdateIdentity(user2, newIdentity.address, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
-        await agentManager.addWhiteListManager(user1Contract.address, { from: admin });
-        (await agentManager.isWhiteListManager(user1Contract.address)).should.be.equal(true);
-        await identityRegistry.addAgent(agentManager.address, { from: tokeny });
-	    await agentManager.callUpdateIdentity(user2, newIdentity.address, user1Contract.address, { from: user1 });
-	    const updated = await identityRegistry.getIdentityOfWallet(user2);
-	    updated.toString().should.equal(newIdentity.address);
-    });
+  it('Should remove recovery agent from the role manager.', async () => {
+    await agentManager.addRecoveryAgent(user1Contract.address, { from: admin });
+    await agentManager.removeRecoveryAgent(user1Contract.address, { from: admin });
+    (await agentManager.isRecoveryAgent(user1Contract.address)).should.be.equal(false);
+  });
 
-    it('Should update country if called by whitelist manager', async () => {
-        await agentManager.callUpdateCountry(user2, 84, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
-        await agentManager.addWhiteListManager(user1Contract.address, { from: admin });
-        (await agentManager.isWhiteListManager(user1Contract.address)).should.be.equal(true);
-        await identityRegistry.addAgent(agentManager.address, { from: tokeny });
-	    await agentManager.callUpdateCountry(user2, 84, user1Contract.address, { from: user1 });
-	    const country = await identityRegistry.getInvestorCountryOfWallet(user2);
-	    country.toString().should.equal('84');
-    });
+  it('Should add and remove compliance agent from the role manager.', async () => {
+    await agentManager.addComplianceAgent(user1Contract.address, { from: admin });
+    (await agentManager.isComplianceAgent(user1Contract.address)).should.be.equal(true);
+    await agentManager.removeComplianceAgent(user1Contract.address, { from: admin });
+    (await agentManager.isComplianceAgent(user1Contract.address)).should.be.equal(false);
+  });
 
-    it('Should delete identity if called by whitelist manager', async () => {
-        await agentManager.callDeleteIdentity(user2, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
-        await agentManager.addWhiteListManager(user1Contract.address, { from: admin });
-        (await agentManager.isWhiteListManager(user1Contract.address)).should.be.equal(true);
-        await identityRegistry.addAgent(agentManager.address, { from: tokeny });
-	    await agentManager.callDeleteIdentity(user2, user1Contract.address, { from: user1 });
-	    const result = await identityRegistry.contains(user2);
-	    result.should.equal(false);
-	});
-	
-	it('Should remove whitelist manager from the role manager.', async () => {
-        await agentManager.addWhiteListManager(user1Contract.address, { from: admin });
-        await agentManager.removeWhiteListManager(user1Contract.address, { from: admin });
-        (await agentManager.isWhiteListManager(user1Contract.address)).should.be.equal(false);
-    });
+  it('Should register identity if called by whitelist manager', async () => {
+    let newUser = accounts[6];
+    let identity = await ClaimHolder.new({ from: accounts[6] });
+    await agentManager.callRegisterIdentity(newUser, identity.address, 100, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    await agentManager.addWhiteListManager(user1Contract.address, { from: admin });
+    (await agentManager.isWhiteListManager(user1Contract.address)).should.be.equal(true);
+    await identityRegistry.addAgent(agentManager.address, { from: tokeny });
+    await agentManager.callRegisterIdentity(newUser, identity.address, 100, user1Contract.address, { from: user1 });
+    const registered = await identityRegistry.contains(newUser);
+    registered.toString().should.equal('true');
+  });
 
-    it('Should not add or remove roles if not admin', async () => {
-        await agentManager.addWhiteListManager(user1Contract.address, { from: tokeny }).should.be.rejectedWith(EVMRevert);
-    });
+  it('Should update identity if called by whitelist manager', async () => {
+    let newIdentity = await ClaimHolder.new({ from: user2 });
+    await agentManager.callUpdateIdentity(user2, newIdentity.address, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    await agentManager.addWhiteListManager(user1Contract.address, { from: admin });
+    (await agentManager.isWhiteListManager(user1Contract.address)).should.be.equal(true);
+    await identityRegistry.addAgent(agentManager.address, { from: tokeny });
+    await agentManager.callUpdateIdentity(user2, newIdentity.address, user1Contract.address, { from: user1 });
+    const updated = await identityRegistry.getIdentityOfWallet(user2);
+    updated.toString().should.equal(newIdentity.address);
+  });
+
+  it('Should update country if called by whitelist manager', async () => {
+    await agentManager.callUpdateCountry(user2, 84, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    await agentManager.addWhiteListManager(user1Contract.address, { from: admin });
+    (await agentManager.isWhiteListManager(user1Contract.address)).should.be.equal(true);
+    await identityRegistry.addAgent(agentManager.address, { from: tokeny });
+    await agentManager.callUpdateCountry(user2, 84, user1Contract.address, { from: user1 });
+    const country = await identityRegistry.getInvestorCountryOfWallet(user2);
+    country.toString().should.equal('84');
+  });
+
+  it('Should delete identity if called by whitelist manager', async () => {
+    await agentManager.callDeleteIdentity(user2, user1Contract.address, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    await agentManager.addWhiteListManager(user1Contract.address, { from: admin });
+    (await agentManager.isWhiteListManager(user1Contract.address)).should.be.equal(true);
+    await identityRegistry.addAgent(agentManager.address, { from: tokeny });
+    await agentManager.callDeleteIdentity(user2, user1Contract.address, { from: user1 });
+    const result = await identityRegistry.contains(user2);
+    result.should.equal(false);
+  });
+
+  it('Should remove whitelist manager from the role manager.', async () => {
+    await agentManager.addWhiteListManager(user1Contract.address, { from: admin });
+    (await agentManager.isWhiteListManager(user1Contract.address)).should.be.equal(true);
+    await agentManager.removeWhiteListManager(user1Contract.address, { from: admin });
+    (await agentManager.isWhiteListManager(user1Contract.address)).should.be.equal(false);
+  });
+
+  it('Should not add or remove roles if not admin', async () => {
+    await agentManager.addWhiteListManager(user1Contract.address, { from: tokeny }).should.be.rejectedWith(EVMRevert);
+  });
 });

--- a/test/compliance.test.js
+++ b/test/compliance.test.js
@@ -2,8 +2,8 @@ const Web3 = require('web3');
 require('chai')
   .use(require('chai-as-promised'))
   .should();
-const log = require('./helpers/logger');
 const EVMRevert = require('./helpers/VMExceptionRevert');
+
 const web3 = new Web3(new Web3.providers.HttpProvider('http://localhost:8545'));
 const ClaimTopicsRegistry = artifacts.require('../contracts/registry/ClaimTopicsRegistry.sol');
 const IdentityRegistry = artifacts.require('../contracts/registry/IdentityRegistry.sol');
@@ -108,7 +108,7 @@ contract('Compliance', accounts => {
   it('Should update the token holders when minted', async () => {
     await token.mint(user1, 1000, { from: agent });
     await token.mint(user2, 100, { from: agent });
-    let holderCount = await limitCompliance.holderCount();
+    const holderCount = await limitCompliance.holderCount();
     holderCount.toString().should.be.equal('2');
   });
 
@@ -123,27 +123,27 @@ contract('Compliance', accounts => {
   it('Should update the token holders when token burnt', async () => {
     await token.mint(user1, 1000, { from: agent });
     await token.mint(user2, 100, { from: agent });
-    let holderCount = await limitCompliance.holderCount();
+    const holderCount = await limitCompliance.holderCount();
     holderCount.toString().should.be.equal('2');
     await token.burn(user2, 100, { from: agent });
-    let newHolderCount = await limitCompliance.holderCount();
+    const newHolderCount = await limitCompliance.holderCount();
     newHolderCount.toString().should.be.equal('1');
   });
 
   it('Should not update the token holders when balance is not reducing to zero', async () => {
     await token.mint(user1, 1000, { from: agent });
     await token.mint(user2, 100, { from: agent });
-    let holderCount = await limitCompliance.holderCount();
+    const holderCount = await limitCompliance.holderCount();
     holderCount.toString().should.be.equal('2');
     await token.burn(user1, 50, { from: agent });
-    let newHolderCount = await limitCompliance.holderCount();
+    const newHolderCount = await limitCompliance.holderCount();
     newHolderCount.toString().should.be.equal(holderCount.toString());
   });
 
   it('Should mint if holder limit do not exceed', async () => {
     await token.mint(user1, 1000, { from: agent });
     await token.mint(user2, 100, { from: agent });
-    let user = accounts[4];
+    const user = accounts[4];
     // tokeny deploys a identity contract for user
     const userContract = await ClaimHolder.new({ from: tokeny });
 
@@ -206,5 +206,10 @@ contract('Compliance', accounts => {
     (await limitCompliance.holderCount()).toString().should.equal('2');
     await token.transfer(user2, 500, { from: user1 }).should.be.fulfilled;
     (await limitCompliance.holderCount()).toString().should.equal('2');
+  });
+
+  it('Should transfer ownership of the compliance contract', async () => {
+    await limitCompliance.transferOwnershipOnComplianceContract(user1, { from: tokeny }).should.be.fulfilled;
+    (await limitCompliance.owner()).should.equal(user1);
   });
 });

--- a/test/compliance.test.js
+++ b/test/compliance.test.js
@@ -1,0 +1,210 @@
+const Web3 = require('web3');
+require('chai')
+  .use(require('chai-as-promised'))
+  .should();
+const log = require('./helpers/logger');
+const EVMRevert = require('./helpers/VMExceptionRevert');
+const web3 = new Web3(new Web3.providers.HttpProvider('http://localhost:8545'));
+const ClaimTopicsRegistry = artifacts.require('../contracts/registry/ClaimTopicsRegistry.sol');
+const IdentityRegistry = artifacts.require('../contracts/registry/IdentityRegistry.sol');
+const TrustedIssuersRegistry = artifacts.require('../contracts/registry/TrustedIssuersRegistry.sol');
+const ClaimHolder = artifacts.require('@onchain-id/solidity/contracts/Identity.sol');
+const IssuerIdentity = artifacts.require('@onchain-id/solidity/contracts/ClaimIssuer.sol');
+const Token = artifacts.require('../contracts/token/Token.sol');
+const Compliance = artifacts.require('../contracts/compliance/DefaultCompliance.sol');
+const LimitCompliance = artifacts.require('../contracts/compliance/LimitHolder.sol');
+
+contract('Compliance', accounts => {
+  let claimTopicsRegistry;
+  let identityRegistry;
+  let trustedIssuersRegistry;
+  let claimIssuerContract;
+  let token;
+  let defaultCompliance;
+  let limitCompliance;
+  let tokenName;
+  let tokenSymbol;
+  let tokenDecimals;
+  let tokenVersion;
+  let tokenOnchainID;
+  const signer = web3.eth.accounts.create();
+  const signerKey = web3.utils.keccak256(web3.eth.abi.encodeParameter('address', signer.address));
+  const tokeny = accounts[0];
+  const claimIssuer = accounts[1];
+  const user1 = accounts[2];
+  const user2 = accounts[3];
+  const claimTopics = [1, 7, 3];
+  let user1Contract;
+  let user2Contract;
+  const agent = accounts[8];
+
+  beforeEach(async () => {
+    // Tokeny deploying token
+    claimTopicsRegistry = await ClaimTopicsRegistry.new({ from: tokeny });
+    trustedIssuersRegistry = await TrustedIssuersRegistry.new({ from: tokeny });
+    defaultCompliance = await Compliance.new({ from: tokeny });
+    identityRegistry = await IdentityRegistry.new(trustedIssuersRegistry.address, claimTopicsRegistry.address, { from: tokeny });
+    tokenOnchainID = await ClaimHolder.new({ from: tokeny });
+    tokenName = 'TREXDINO';
+    tokenSymbol = 'TREX';
+    tokenDecimals = '0';
+    tokenVersion = '1.2';
+    token = await Token.new(
+      identityRegistry.address,
+      defaultCompliance.address,
+      tokenName,
+      tokenSymbol,
+      tokenDecimals,
+      tokenVersion,
+      tokenOnchainID.address,
+      { from: tokeny },
+    );
+    limitCompliance = await LimitCompliance.new(token.address, 2, { from: tokeny });
+    await token.addAgent(agent, { from: tokeny });
+    // Tokeny adds trusted claim Topic to claim topics registry
+    await claimTopicsRegistry.addClaimTopic(7, { from: tokeny }).should.be.fulfilled;
+    // Claim issuer deploying identity contract
+    claimIssuerContract = await IssuerIdentity.new({ from: claimIssuer });
+    // Claim issuer adds claim signer key to his contract
+    await claimIssuerContract.addKey(signerKey, 3, 1, { from: claimIssuer }).should.be.fulfilled;
+    // Tokeny adds trusted claim Issuer to claimIssuer registry
+    await trustedIssuersRegistry.addTrustedIssuer(claimIssuerContract.address, 1, claimTopics, { from: tokeny }).should.be.fulfilled;
+    // user1 deploys his identity contract
+    user1Contract = await ClaimHolder.new({ from: user1 });
+    // user2 deploys his identity contract
+    user2Contract = await ClaimHolder.new({ from: user2 });
+    // identity contracts are registered in identity registry
+    await identityRegistry.addAgent(agent, { from: tokeny });
+    await identityRegistry.registerIdentity(user1, user1Contract.address, 91, {
+      from: agent,
+    }).should.be.fulfilled;
+    await identityRegistry.registerIdentity(user2, user2Contract.address, 101, {
+      from: agent,
+    }).should.be.fulfilled;
+    // user1 gets signature from claim issuer
+    const hexedData1 = await web3.utils.asciiToHex('Yea no, this guy is totes legit');
+    const hashedDataToSign1 = web3.utils.keccak256(
+      web3.eth.abi.encodeParameters(['address', 'uint256', 'bytes'], [user1Contract.address, 7, hexedData1]),
+    );
+    const signature1 = (await signer.sign(hashedDataToSign1)).signature;
+    // user1 adds claim to identity contract
+    await user1Contract.addClaim(7, 1, claimIssuerContract.address, signature1, hexedData1, '', { from: user1 });
+    // user2 gets signature from claim issuer
+    const hexedData2 = await web3.utils.asciiToHex('Yea no, this guy is totes legit');
+    const hashedDataToSign2 = web3.utils.keccak256(
+      web3.eth.abi.encodeParameters(['address', 'uint256', 'bytes'], [user2Contract.address, 7, hexedData2]),
+    );
+    const signature2 = (await signer.sign(hashedDataToSign2)).signature;
+    // user2 adds claim to identity contract
+    await user2Contract.addClaim(7, 1, claimIssuerContract.address, signature2, hexedData2, '', { from: user2 }).should.be.fulfilled;
+    await token.setCompliance(limitCompliance.address, { from: tokeny });
+    await limitCompliance.addAgent(token.address, { from: tokeny });
+  });
+
+  it('compliance should be changed to limit holder.', async () => {
+    (await token.getCompliance()).should.be.equal(limitCompliance.address);
+  });
+
+  it('Should update the token holders when minted', async () => {
+    await token.mint(user1, 1000, { from: agent });
+    await token.mint(user2, 100, { from: agent });
+    let holderCount = await limitCompliance.holderCount();
+    holderCount.toString().should.be.equal('2');
+  });
+
+  it('Should retreive the token holders list', async () => {
+    await token.mint(user1, 1000, { from: agent });
+    await token.mint(user2, 100, { from: agent });
+    (await limitCompliance.holderAt(0)).should.be.equal(user1);
+    (await limitCompliance.holderAt(1)).should.be.equal(user2);
+    await limitCompliance.holderAt(2).should.be.rejectedWith(EVMRevert);
+  });
+
+  it('Should update the token holders when token burnt', async () => {
+    await token.mint(user1, 1000, { from: agent });
+    await token.mint(user2, 100, { from: agent });
+    let holderCount = await limitCompliance.holderCount();
+    holderCount.toString().should.be.equal('2');
+    await token.burn(user2, 100, { from: agent });
+    let newHolderCount = await limitCompliance.holderCount();
+    newHolderCount.toString().should.be.equal('1');
+  });
+
+  it('Should not update the token holders when balance is not reducing to zero', async () => {
+    await token.mint(user1, 1000, { from: agent });
+    await token.mint(user2, 100, { from: agent });
+    let holderCount = await limitCompliance.holderCount();
+    holderCount.toString().should.be.equal('2');
+    await token.burn(user1, 50, { from: agent });
+    let newHolderCount = await limitCompliance.holderCount();
+    newHolderCount.toString().should.be.equal(holderCount.toString());
+  });
+
+  it('Should mint if holder limit do not exceed', async () => {
+    await token.mint(user1, 1000, { from: agent });
+    await token.mint(user2, 100, { from: agent });
+    let user = accounts[4];
+    // tokeny deploys a identity contract for user
+    const userContract = await ClaimHolder.new({ from: tokeny });
+
+    // identity contracts are registered in identity registry
+    await identityRegistry.registerIdentity(user, userContract.address, 91, { from: agent }).should.be.fulfilled;
+
+    // user gets signature from claim issuer
+    const hexedData = await web3.utils.asciiToHex('Yea no, this guy is totes legit');
+
+    const hashedDataToSign = web3.utils.keccak256(
+      web3.eth.abi.encodeParameters(['address', 'uint256', 'bytes'], [userContract.address, 7, hexedData]),
+    );
+
+    const signature = (await signer.sign(hashedDataToSign)).signature;
+
+    // tokeny adds claim to identity contract
+    await userContract.addClaim(7, 1, claimIssuerContract.address, signature, hexedData, '', { from: tokeny });
+
+    // tokeny mint the tokens to the user
+    await token.mint(user, 1000, { from: agent }); //.should.be.rejectedWith(EVMRevert);
+  });
+
+  it('Should revert if no tokens minted', async () => {
+    await token.mint(user1, 0, { from: agent }).should.be.rejectedWith(EVMRevert);
+  });
+
+  it('Should give holder count by country code', async () => {
+    await token.mint(user1, 1000, { from: agent });
+    (await limitCompliance.getShareholderCountByCountry(91)).toString().should.be.equal('1');
+  });
+
+  it('Should allow transfer if holder limit is not exceeding', async () => {
+    await token.mint(user1, 1500, { from: agent });
+
+    const user3 = accounts[4];
+    // tokeny deploys a identity contract for user
+    const userContract = await ClaimHolder.new({ from: tokeny });
+    // identity contracts are registered in identity registry
+    await identityRegistry.registerIdentity(user3, userContract.address, 91, { from: agent }).should.be.fulfilled;
+
+    // user gets signature from claim issuer
+    const hexedData = await web3.utils.asciiToHex('Yea no, this guy is totes legit');
+
+    const hashedDataToSign = web3.utils.keccak256(
+      web3.eth.abi.encodeParameters(['address', 'uint256', 'bytes'], [userContract.address, 7, hexedData]),
+    );
+
+    const signature = (await signer.sign(hashedDataToSign)).signature;
+
+    // tokeny adds claim to identity contract
+    await userContract.addClaim(7, 1, claimIssuerContract.address, signature, hexedData, '', { from: tokeny });
+
+    await token.transfer(user2, 500, { from: user1 }).should.be.fulfilled;
+    await token.transfer(user3, 500, { from: user1 }).should.be.rejectedWith(EVMRevert);
+  });
+
+  it('Should not update shareholder count if user is an existing holder.', async () => {
+    await token.mint(user1, 1000, { from: agent }).should.be.fulfilled;
+	await token.mint(user2, 1000, { from: agent }).should.be.fulfilled;
+	(await limitCompliance.holderCount()).toString().should.equal('2');
+	await token.transfer(user2, 500, { from: user1 }).should.be.fulfilled;
+	(await limitCompliance.holderCount()).toString().should.equal('2');
+  });
+});

--- a/test/compliance.test.js
+++ b/test/compliance.test.js
@@ -163,7 +163,7 @@ contract('Compliance', accounts => {
     await userContract.addClaim(7, 1, claimIssuerContract.address, signature, hexedData, '', { from: tokeny });
 
     // tokeny mint the tokens to the user
-    await token.mint(user, 1000, { from: agent }); //.should.be.rejectedWith(EVMRevert);
+    await token.mint(user, 1000, { from: agent }).should.be.rejectedWith(EVMRevert);
   });
 
   it('Should revert if no tokens minted', async () => {
@@ -202,9 +202,9 @@ contract('Compliance', accounts => {
 
   it('Should not update shareholder count if user is an existing holder.', async () => {
     await token.mint(user1, 1000, { from: agent }).should.be.fulfilled;
-	await token.mint(user2, 1000, { from: agent }).should.be.fulfilled;
-	(await limitCompliance.holderCount()).toString().should.equal('2');
-	await token.transfer(user2, 500, { from: user1 }).should.be.fulfilled;
-	(await limitCompliance.holderCount()).toString().should.equal('2');
+    await token.mint(user2, 1000, { from: agent }).should.be.fulfilled;
+    (await limitCompliance.holderCount()).toString().should.equal('2');
+    await token.transfer(user2, 500, { from: user1 }).should.be.fulfilled;
+    (await limitCompliance.holderCount()).toString().should.equal('2');
   });
 });

--- a/test/identity.test.js
+++ b/test/identity.test.js
@@ -12,11 +12,7 @@ contract('Identity', accounts => {
   const key = web3.utils.keccak256(web3.eth.abi.encodeParameter('address', accounts[0]));
 
   beforeEach(async () => {
-    // keyHolder = await KeyHolder.new({ from: accounts[0] });
     claimHolder = await ClaimHolder.new({ from: accounts[0] });
-    // Claim issuer adds claim signer key to his contract
-    // await claimHolder.addKey(signerKey, 3, 1).should.be.fulfilled;
-
     await claimHolder.addClaim(1, 1, accounts[5], '0x24', '0x12', '');
   });
 
@@ -35,9 +31,6 @@ contract('Identity', accounts => {
     await claimHolder.addKey(newKey, 3, 1, { from: accounts[1] }).should.be.rejectedWith(EVMRevert);
   });
 
-  // it('Add key should fail if the provided key already exists', async () => {
-  //   await claimHolder.addKey(key, 2, 1).should.be.rejectedWith(EVMRevert);
-  // })
   it('Add key should fail if the provided key purpose already exists', async () => {
     await claimHolder.addKey(key, 1, 1).should.be.rejectedWith(EVMRevert);
   });

--- a/test/ownerManager.test.js
+++ b/test/ownerManager.test.js
@@ -338,14 +338,14 @@ contract('Owner Manager', accounts => {
   it('Should set token information in the token only if onchainID is registered as TokenInfoManager', async () => {
     const tokenInfoManager = accounts[6];
     const tokenInfoManagerIdentity = await ClaimHolder.new({ from: tokenInfoManager });
-    //should revert if sender is not token info manager
+    // should revert if sender is not token info manager
     await ownerManager
       .callSetTokenInformation('TREXDINO1', 'TREX1', 1, '1.3', '0x0000000000000000000000000000000000000000', tokenInfoManagerIdentity.address, {
         from: tokenInfoManager,
       })
       .should.be.rejectedWith(EVMRevert);
 
-    //should set information if sender is token info manager
+    // should set information if sender is token info manager
     await ownerManager.addTokenInfoManager(tokenInfoManagerIdentity.address, { from: tokeny }).should.be.fulfilled;
     (await ownerManager.isTokenInfoManager(tokenInfoManagerIdentity.address)).should.be.equal(true);
     await ownerManager.callSetTokenInformation(
@@ -368,15 +368,15 @@ contract('Owner Manager', accounts => {
     const claimRegistryManager = accounts[6];
     const claimRegistryManagerIdentity = await ClaimHolder.new({ from: claimRegistryManager });
 
-    //should revert if sender is not claim registry manager
+    // should revert if sender is not claim registry manager
     await ownerManager.callAddClaimTopic(5, claimRegistryManagerIdentity.address, { from: claimRegistryManager }).should.be.rejectedWith(EVMRevert);
 
-    //should add claim topic if sender is claim registry manager
+    // should add claim topic if sender is claim registry manager
     await ownerManager.addClaimRegistryManager(claimRegistryManagerIdentity.address, { from: tokeny });
     (await ownerManager.isClaimRegistryManager(claimRegistryManagerIdentity.address)).should.be.equal(true);
     await ownerManager.callAddClaimTopic(5, claimRegistryManagerIdentity.address, { from: claimRegistryManager }).should.be.fulfilled;
-    //check if claim topic added
-    let topic = await claimTopicsRegistry.getClaimTopics();
+    // check if claim topic added
+    const topic = await claimTopicsRegistry.getClaimTopics();
     topic[1].toString().should.equal('5');
   });
 
@@ -384,14 +384,14 @@ contract('Owner Manager', accounts => {
     const claimRegistryManager = accounts[6];
     const claimRegistryManagerIdentity = await ClaimHolder.new({ from: claimRegistryManager });
 
-    //should revert if sender is not claim registry manager
+    // should revert if sender is not claim registry manager
     await ownerManager
       .callRemoveClaimTopic(7, claimRegistryManagerIdentity.address, { from: claimRegistryManager })
       .should.be.rejectedWith(EVMRevert);
     let topic = await claimTopicsRegistry.getClaimTopics();
     topic.length.should.equal(1);
 
-    //should add claim topic if sender is claim registry manager
+    // should add claim topic if sender is claim registry manager
     await ownerManager.addClaimRegistryManager(claimRegistryManagerIdentity.address, { from: tokeny });
     (await ownerManager.isClaimRegistryManager(claimRegistryManagerIdentity.address)).should.be.equal(true);
     await ownerManager.callRemoveClaimTopic(7, claimRegistryManagerIdentity.address, { from: claimRegistryManager }).should.be.fulfilled;
@@ -414,7 +414,7 @@ contract('Owner Manager', accounts => {
   });
 
   it('Should add and remove agent in token contract', async () => {
-    let newAgent = accounts[6];
+    const newAgent = accounts[6];
     await ownerManager.callAddAgentOnTokenContract(newAgent, { from: tokeny }).should.be.fulfilled;
     (await token.isAgent(newAgent)).should.equal(true);
     await ownerManager.callRemoveAgentOnTokenContract(newAgent, { from: tokeny }).should.be.fulfilled;
@@ -422,7 +422,7 @@ contract('Owner Manager', accounts => {
   });
 
   it('Should add and remove agent in identity registry contract', async () => {
-    let newAgent = accounts[6];
+    const newAgent = accounts[6];
     await ownerManager.callAddAgentOnIdentityRegistryContract(newAgent, { from: tokeny }).should.be.fulfilled;
     (await identityRegistry.isAgent(newAgent)).should.equal(true);
     await ownerManager.callRemoveAgentOnIdentityRegistryContract(newAgent, { from: tokeny }).should.be.fulfilled;

--- a/test/ownerManager.test.js
+++ b/test/ownerManager.test.js
@@ -1,0 +1,431 @@
+const Web3 = require('web3');
+require('chai')
+  .use(require('chai-as-promised'))
+  .should();
+const EVMRevert = require('./helpers/VMExceptionRevert');
+
+const web3 = new Web3(new Web3.providers.HttpProvider('http://localhost:8545'));
+
+const ClaimTopicsRegistry = artifacts.require('../contracts/registry/ClaimTopicsRegistry.sol');
+const IdentityRegistry = artifacts.require('../contracts/registry/IdentityRegistry.sol');
+const TrustedIssuersRegistry = artifacts.require('../contracts/registry/TrustedIssuersRegistry.sol');
+const ClaimHolder = artifacts.require('@onchain-id/solidity/contracts/Identity.sol');
+const IssuerIdentity = artifacts.require('@onchain-id/solidity/contracts/ClaimIssuer.sol');
+const Token = artifacts.require('../contracts/token/Token.sol');
+const Compliance = artifacts.require('../contracts/compliance/DefaultCompliance.sol');
+const OwnerManager = artifacts.require('../contracts/roles/OwnerManager.sol');
+
+contract('Owner Manager', accounts => {
+  let claimTopicsRegistry;
+  let identityRegistry;
+  let trustedIssuersRegistry;
+  let claimIssuerContract;
+  let token;
+  let ownerManager;
+  let defaultCompliance;
+  let tokenName;
+  let tokenSymbol;
+  let tokenDecimals;
+  let tokenVersion;
+  let tokenOnchainID;
+  const signer = web3.eth.accounts.create();
+  const signerKey = web3.utils.keccak256(web3.eth.abi.encodeParameter('address', signer.address));
+
+  const tokeny = accounts[0];
+  const claimIssuer = accounts[1];
+  const user1 = accounts[2];
+  const user2 = accounts[3];
+  const claimTopics = [1, 7, 3];
+  let user1Contract;
+  let user2Contract;
+
+  beforeEach(async () => {
+    // Tokeny deploying token
+    claimTopicsRegistry = await ClaimTopicsRegistry.new({ from: tokeny });
+    trustedIssuersRegistry = await TrustedIssuersRegistry.new({ from: tokeny });
+    defaultCompliance = await Compliance.new({ from: tokeny });
+    identityRegistry = await IdentityRegistry.new(trustedIssuersRegistry.address, claimTopicsRegistry.address, { from: tokeny });
+    tokenOnchainID = await ClaimHolder.new({ from: tokeny });
+    tokenName = 'TREXDINO';
+    tokenSymbol = 'TREX';
+    tokenDecimals = '0';
+    tokenVersion = '1.2';
+    token = await Token.new(
+      identityRegistry.address,
+      defaultCompliance.address,
+      tokenName,
+      tokenSymbol,
+      tokenDecimals,
+      tokenVersion,
+      tokenOnchainID.address,
+      { from: tokeny },
+    );
+    ownerManager = await OwnerManager.new(token.address, { from: tokeny });
+
+    // Tokeny adds trusted claim Topic to claim topics registry
+    await claimTopicsRegistry.addClaimTopic(7, { from: tokeny }).should.be.fulfilled;
+
+    // Claim issuer deploying identity contract
+    claimIssuerContract = await IssuerIdentity.new({ from: claimIssuer });
+
+    // Claim issuer adds claim signer key to his contract
+    await claimIssuerContract.addKey(signerKey, 3, 1, { from: claimIssuer }).should.be.fulfilled;
+
+    // Tokeny adds trusted claim Issuer to claimIssuer registry
+    await trustedIssuersRegistry.addTrustedIssuer(claimIssuerContract.address, 1, claimTopics, { from: tokeny }).should.be.fulfilled;
+
+    // user1 deploys his identity contract
+    user1Contract = await ClaimHolder.new({ from: user1 });
+
+    // user2 deploys his identity contract
+    user2Contract = await ClaimHolder.new({ from: user2 });
+
+    // user1 gets signature from claim issuer
+    const hexedData1 = await web3.utils.asciiToHex('Yea no, this guy is totes legit');
+    const hashedDataToSign1 = web3.utils.keccak256(
+      web3.eth.abi.encodeParameters(['address', 'uint256', 'bytes'], [user1Contract.address, 7, hexedData1]),
+    );
+
+    const signature1 = (await signer.sign(hashedDataToSign1)).signature;
+
+    // user1 adds claim to identity contract
+    await user1Contract.addClaim(7, 1, claimIssuerContract.address, signature1, hexedData1, '', { from: user1 });
+
+    // user2 gets signature from claim issuer
+    const hexedData2 = await web3.utils.asciiToHex('Yea no, this guy is totes legit');
+    const hashedDataToSign2 = web3.utils.keccak256(
+      web3.eth.abi.encodeParameters(['address', 'uint256', 'bytes'], [user2Contract.address, 7, hexedData2]),
+    );
+
+    const signature2 = (await signer.sign(hashedDataToSign2)).signature;
+
+    // user2 adds claim to identity contract
+    await user2Contract.addClaim(7, 1, claimIssuerContract.address, signature2, hexedData2, '', { from: user2 }).should.be.fulfilled;
+
+    // set ownerManager as owner of all contracts
+    await ownerManager.addOwnerAdmin(tokeny, { from: tokeny });
+    await token.transferOwnershipOnTokenContract(ownerManager.address, { from: tokeny });
+    await identityRegistry.transferOwnershipOnIdentityRegistryContract(ownerManager.address, { from: tokeny });
+    await claimTopicsRegistry.transferOwnershipOnClaimTopicsRegistryContract(ownerManager.address, { from: tokeny });
+    await trustedIssuersRegistry.transferOwnershipOnIssuersRegistryContract(ownerManager.address, { from: tokeny });
+    await defaultCompliance.transferOwnershipOnComplianceContract(ownerManager.address, { from: tokeny });
+  });
+
+  it('Should add and remove ownerAdmin role on OwnerManager', async () => {
+    const admin = accounts[6];
+    // try to add role without being admin
+    await ownerManager.addOwnerAdmin(admin, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    (await ownerManager.isOwnerAdmin(admin)).should.be.equal(false);
+    // add role as admin
+    await ownerManager.addOwnerAdmin(admin, { from: tokeny });
+    (await ownerManager.isOwnerAdmin(admin)).should.be.equal(true);
+    // try to remove role without being admin
+    await ownerManager.removeOwnerAdmin(admin, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    (await ownerManager.isOwnerAdmin(admin)).should.be.equal(true);
+    // remove role as admin
+    await ownerManager.removeOwnerAdmin(admin, { from: tokeny });
+    (await ownerManager.isOwnerAdmin(admin)).should.be.equal(false);
+  });
+
+  it('Should add and remove registryAddressSetter role on OwnerManager', async () => {
+    const registrySetter = accounts[6];
+    // try to add role without being admin
+    await ownerManager.addRegistryAddressSetter(registrySetter, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    (await ownerManager.isRegistryAddressSetter(registrySetter)).should.be.equal(false);
+    // add role as admin
+    await ownerManager.addRegistryAddressSetter(registrySetter, { from: tokeny });
+    (await ownerManager.isRegistryAddressSetter(registrySetter)).should.be.equal(true);
+    // try to remove role without being admin
+    await ownerManager.removeRegistryAddressSetter(registrySetter, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    (await ownerManager.isRegistryAddressSetter(registrySetter)).should.be.equal(true);
+    // remove role as admin
+    await ownerManager.removeRegistryAddressSetter(registrySetter, { from: tokeny });
+    (await ownerManager.isRegistryAddressSetter(registrySetter)).should.be.equal(false);
+  });
+
+  it('Should add and remove complianceSetter role on OwnerManager', async () => {
+    const complianceSetter = accounts[6];
+    // try to add role without being admin
+    await ownerManager.addComplianceSetter(complianceSetter, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    (await ownerManager.isComplianceSetter(complianceSetter)).should.be.equal(false);
+    // add role as admin
+    await ownerManager.addComplianceSetter(complianceSetter, { from: tokeny });
+    (await ownerManager.isComplianceSetter(complianceSetter)).should.be.equal(true);
+    // try to remove role without being admin
+    await ownerManager.removeComplianceSetter(complianceSetter, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    (await ownerManager.isComplianceSetter(complianceSetter)).should.be.equal(true);
+    // remove role as admin
+    await ownerManager.removeComplianceSetter(complianceSetter, { from: tokeny });
+    (await ownerManager.isComplianceSetter(complianceSetter)).should.be.equal(false);
+  });
+
+  it('Should add and remove claimRegistryManager role on OwnerManager', async () => {
+    const claimRegistryManager = accounts[6];
+    // try to add role without being admin
+    await ownerManager.addClaimRegistryManager(claimRegistryManager, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    (await ownerManager.isClaimRegistryManager(claimRegistryManager)).should.be.equal(false);
+    // add role as admin
+    await ownerManager.addClaimRegistryManager(claimRegistryManager, { from: tokeny });
+    (await ownerManager.isClaimRegistryManager(claimRegistryManager)).should.be.equal(true);
+    // try to remove role without being admin
+    await ownerManager.removeClaimRegistryManager(claimRegistryManager, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    (await ownerManager.isClaimRegistryManager(claimRegistryManager)).should.be.equal(true);
+    // remove role as admin
+    await ownerManager.removeClaimRegistryManager(claimRegistryManager, { from: tokeny });
+    (await ownerManager.isClaimRegistryManager(claimRegistryManager)).should.be.equal(false);
+  });
+
+  it('Should add and remove issuersRegistryManager role on OwnerManager', async () => {
+    const issuersRegistryManager = accounts[6];
+    // try to add role without being admin
+    await ownerManager.addIssuersRegistryManager(issuersRegistryManager, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    (await ownerManager.isIssuersRegistryManager(issuersRegistryManager)).should.be.equal(false);
+    // add role as admin
+    await ownerManager.addIssuersRegistryManager(issuersRegistryManager, { from: tokeny });
+    (await ownerManager.isIssuersRegistryManager(issuersRegistryManager)).should.be.equal(true);
+    // try to remove role without being admin
+    await ownerManager.removeIssuersRegistryManager(issuersRegistryManager, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    (await ownerManager.isIssuersRegistryManager(issuersRegistryManager)).should.be.equal(true);
+    // remove role as admin
+    await ownerManager.removeIssuersRegistryManager(issuersRegistryManager, { from: tokeny });
+    (await ownerManager.isIssuersRegistryManager(issuersRegistryManager)).should.be.equal(false);
+  });
+
+  it('Should add and remove tokenInfoManager role on OwnerManager', async () => {
+    const tokenInfoManager = accounts[6];
+    // try to add role without being admin
+    await ownerManager.addTokenInfoManager(tokenInfoManager, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    (await ownerManager.isTokenInfoManager(tokenInfoManager)).should.be.equal(false);
+    // add role as admin
+    await ownerManager.addTokenInfoManager(tokenInfoManager, { from: tokeny });
+    (await ownerManager.isTokenInfoManager(tokenInfoManager)).should.be.equal(true);
+    // try to remove role without being admin
+    await ownerManager.removeTokenInfoManager(tokenInfoManager, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    (await ownerManager.isTokenInfoManager(tokenInfoManager)).should.be.equal(true);
+    // remove role as admin
+    await ownerManager.removeTokenInfoManager(tokenInfoManager, { from: tokeny });
+    (await ownerManager.isTokenInfoManager(tokenInfoManager)).should.be.equal(false);
+  });
+
+  it('Should set identity registry only if onchainID is registered as registryAddressSetter', async () => {
+    const registrySetter = user1;
+    const registrySetterID = user1Contract;
+    await ownerManager.addRegistryAddressSetter(registrySetterID.address, { from: tokeny });
+    (await ownerManager.isRegistryAddressSetter(registrySetterID.address)).should.be.equal(true);
+    // create new identity registry contract
+    const identityRegistry2 = await IdentityRegistry.new(trustedIssuersRegistry.address, claimTopicsRegistry.address, { from: registrySetter });
+    // set identity registry on the token contract
+    await ownerManager.callSetIdentityRegistry(identityRegistry2.address, registrySetterID.address, { from: registrySetter });
+    (await token.getIdentityRegistry()).should.be.equal(identityRegistry2.address);
+    // should not work if wallet is not set as management key on the onchainID
+    await ownerManager
+      .callSetIdentityRegistry(identityRegistry2.address, registrySetterID.address, { from: tokeny })
+      .should.be.rejectedWith(EVMRevert);
+    (await token.getIdentityRegistry()).should.be.equal(identityRegistry2.address);
+  });
+
+  it('Should set topics registry only if onchainID is registered as registryAddressSetter', async () => {
+    const registrySetter = user1;
+    const registrySetterID = user1Contract;
+    await ownerManager.addRegistryAddressSetter(registrySetterID.address, { from: tokeny });
+    (await ownerManager.isRegistryAddressSetter(registrySetterID.address)).should.be.equal(true);
+    // create new claim topics registry contract
+    const claimTopicsRegistry2 = await ClaimTopicsRegistry.new({ from: registrySetter });
+    // set claim topics registry on the identity registry contract
+    await ownerManager.callSetClaimTopicsRegistry(claimTopicsRegistry2.address, registrySetterID.address, { from: registrySetter });
+    (await identityRegistry.getTopicsRegistry()).should.be.equal(claimTopicsRegistry2.address);
+    // should not work if wallet is not set as management key on the onchainID
+    await ownerManager
+      .callSetClaimTopicsRegistry(claimTopicsRegistry2.address, registrySetterID.address, { from: tokeny })
+      .should.be.rejectedWith(EVMRevert);
+    (await identityRegistry.getTopicsRegistry()).should.be.equal(claimTopicsRegistry2.address);
+  });
+
+  it('Should set trusted issuers registry only if onchainID is registered as registryAddressSetter', async () => {
+    const registrySetter = user1;
+    const registrySetterID = user1Contract;
+    await ownerManager.addRegistryAddressSetter(registrySetterID.address, { from: tokeny });
+    (await ownerManager.isRegistryAddressSetter(registrySetterID.address)).should.be.equal(true);
+    // create new trusted issuers registry contract
+    const trustedIssuersRegistry2 = await TrustedIssuersRegistry.new({ from: registrySetter });
+    // set trusted issuers registry on the identity registry contract
+    await ownerManager.callSetTrustedIssuersRegistry(trustedIssuersRegistry2.address, registrySetterID.address, { from: registrySetter });
+    (await identityRegistry.getIssuersRegistry()).should.be.equal(trustedIssuersRegistry2.address);
+    // should not work if wallet is not set as management key on the onchainID
+    await ownerManager
+      .callSetTrustedIssuersRegistry(trustedIssuersRegistry2.address, registrySetterID.address, { from: tokeny })
+      .should.be.rejectedWith(EVMRevert);
+    (await identityRegistry.getIssuersRegistry()).should.be.equal(trustedIssuersRegistry2.address);
+  });
+
+  it('Should set compliance contract only if onchainID is registered as registryAddressSetter', async () => {
+    const complianceSetter = user1;
+    const complianceSetterID = user1Contract;
+    await ownerManager.addComplianceSetter(complianceSetterID.address, { from: tokeny });
+    (await ownerManager.isComplianceSetter(complianceSetterID.address)).should.be.equal(true);
+    // create new compliance contract
+    const compliance2 = await Compliance.new({ from: complianceSetter });
+    // set compliance on the token contract
+    await ownerManager.callSetCompliance(compliance2.address, complianceSetterID.address, { from: complianceSetter });
+    (await token.getCompliance()).should.be.equal(compliance2.address);
+    // should not work if wallet is not set as management key on the onchainID
+    await ownerManager.callSetCompliance(compliance2.address, complianceSetterID.address, { from: tokeny }).should.be.rejectedWith(EVMRevert);
+    (await token.getCompliance()).should.be.equal(compliance2.address);
+  });
+
+  it('Should add trusted issuer to the registry only if onchainID is registered as IssuersRegistryManager', async () => {
+    const issuersRegistryManager = user1;
+    const issuersRegistryManagerID = user1Contract;
+    const claimIssuer2 = accounts[6];
+    const claimIssuerContract2 = await IssuerIdentity.new({ from: claimIssuer2 });
+    // add new issuersRegistryManager
+    await ownerManager.addIssuersRegistryManager(issuersRegistryManagerID.address, { from: tokeny });
+    (await ownerManager.isIssuersRegistryManager(issuersRegistryManagerID.address)).should.be.equal(true);
+    // should not work if wallet is not set as management key on the onchainID
+    await ownerManager
+      .callAddTrustedIssuer(claimIssuerContract2.address, 2, claimTopics, issuersRegistryManagerID.address, { from: tokeny })
+      .should.be.rejectedWith(EVMRevert);
+    (await trustedIssuersRegistry.isTrustedIssuer(claimIssuerContract2.address)).should.be.equal(false);
+    // add trusted issuer in the registry
+    await ownerManager.callAddTrustedIssuer(claimIssuerContract2.address, 2, claimTopics, issuersRegistryManagerID.address, {
+      from: issuersRegistryManager,
+    });
+    (await trustedIssuersRegistry.getTrustedIssuer(2)).should.be.equal(claimIssuerContract2.address);
+  });
+
+  it('Should remove trusted issuer from the registry only if onchainID is registered as IssuersRegistryManager', async () => {
+    const issuersRegistryManager = user1;
+    const issuersRegistryManagerID = user1Contract;
+    const claimIssuer2 = accounts[6];
+    const claimIssuerContract2 = await IssuerIdentity.new({ from: claimIssuer2 });
+    // add new issuersRegistryManager
+    await ownerManager.addIssuersRegistryManager(issuersRegistryManagerID.address, { from: tokeny });
+    (await ownerManager.isIssuersRegistryManager(issuersRegistryManagerID.address)).should.be.equal(true);
+    // add trusted issuer in the registry
+    await ownerManager.callAddTrustedIssuer(claimIssuerContract2.address, 2, claimTopics, issuersRegistryManagerID.address, {
+      from: issuersRegistryManager,
+    });
+    (await trustedIssuersRegistry.getTrustedIssuer(2)).should.be.equal(claimIssuerContract2.address);
+    // remove should not work if wallet is not set as management key on the onchainID
+    await ownerManager.callRemoveTrustedIssuer(2, issuersRegistryManagerID.address, { from: tokeny }).should.be.rejectedWith(EVMRevert);
+    (await trustedIssuersRegistry.getTrustedIssuer(2)).should.be.equal(claimIssuerContract2.address);
+    // remove should work if wallet is set as management key on the onchainID
+    await ownerManager.callRemoveTrustedIssuer(2, issuersRegistryManagerID.address, { from: issuersRegistryManager });
+    (await trustedIssuersRegistry.isTrustedIssuer(claimIssuerContract2.address)).should.be.equal(false);
+  });
+
+  it('Should update trusted issuer in the registry only if onchainID is registered as IssuersRegistryManager', async () => {
+    const issuersRegistryManager = user1;
+    const issuersRegistryManagerID = user1Contract;
+    const claimIssuer2 = accounts[6];
+    const claimIssuerContract2 = await IssuerIdentity.new({ from: claimIssuer2 });
+    const claimTopics2 = [4];
+    // add new issuersRegistryManager
+    await ownerManager.addIssuersRegistryManager(issuersRegistryManagerID.address, { from: tokeny });
+    (await ownerManager.isIssuersRegistryManager(issuersRegistryManagerID.address)).should.be.equal(true);
+    // update should not work if wallet is not set as management key on the onchainID
+    await ownerManager
+      .callUpdateIssuerContract(1, claimIssuerContract2.address, claimTopics2, issuersRegistryManagerID.address, { from: tokeny })
+      .should.be.rejectedWith(EVMRevert);
+    (await trustedIssuersRegistry.hasClaimTopic(claimIssuerContract2.address, 4)).should.be.equal(false);
+    // update should work if wallet is set as management key on the onchainID
+    await ownerManager.callUpdateIssuerContract(1, claimIssuerContract2.address, claimTopics2, issuersRegistryManagerID.address, {
+      from: issuersRegistryManager,
+    });
+    (await trustedIssuersRegistry.hasClaimTopic(claimIssuerContract2.address, 4)).should.be.equal(true);
+  });
+
+  it('Should set token information in the token only if onchainID is registered as TokenInfoManager', async () => {
+    const tokenInfoManager = accounts[6];
+    const tokenInfoManagerIdentity = await ClaimHolder.new({ from: tokenInfoManager });
+    //should revert if sender is not token info manager
+    await ownerManager
+      .callSetTokenInformation('TREXDINO1', 'TREX1', 1, '1.3', '0x0000000000000000000000000000000000000000', tokenInfoManagerIdentity.address, {
+        from: tokenInfoManager,
+      })
+      .should.be.rejectedWith(EVMRevert);
+
+    //should set information if sender is token info manager
+    await ownerManager.addTokenInfoManager(tokenInfoManagerIdentity.address, { from: tokeny }).should.be.fulfilled;
+    (await ownerManager.isTokenInfoManager(tokenInfoManagerIdentity.address)).should.be.equal(true);
+    await ownerManager.callSetTokenInformation(
+      'TREXDINO1',
+      'TREX1',
+      1,
+      '1.3',
+      '0x0000000000000000000000000000000000000000',
+      tokenInfoManagerIdentity.address,
+      { from: tokenInfoManager },
+    ).should.be.fulfilled;
+    (await token.name()).should.equal('TREXDINO1');
+    (await token.symbol()).should.equal('TREX1');
+    (await token.decimals()).toString().should.equal('1');
+    (await token.version()).should.equal('1.3');
+    (await token.onchainID()).should.equal('0x0000000000000000000000000000000000000000');
+  });
+
+  it('Should add claim topic in the claim topics registry only if onchainID is registered as ClaimRegistryManager', async () => {
+    const claimRegistryManager = accounts[6];
+    const claimRegistryManagerIdentity = await ClaimHolder.new({ from: claimRegistryManager });
+
+    //should revert if sender is not claim registry manager
+    await ownerManager.callAddClaimTopic(5, claimRegistryManagerIdentity.address, { from: claimRegistryManager }).should.be.rejectedWith(EVMRevert);
+
+    //should add claim topic if sender is claim registry manager
+    await ownerManager.addClaimRegistryManager(claimRegistryManagerIdentity.address, { from: tokeny });
+    (await ownerManager.isClaimRegistryManager(claimRegistryManagerIdentity.address)).should.be.equal(true);
+    await ownerManager.callAddClaimTopic(5, claimRegistryManagerIdentity.address, { from: claimRegistryManager }).should.be.fulfilled;
+    //check if claim topic added
+    let topic = await claimTopicsRegistry.getClaimTopics();
+    topic[1].toString().should.equal('5');
+  });
+
+  it('Should remove claim topic in the claim topics registry only if onchainID is registered as ClaimRegistryManager', async () => {
+    const claimRegistryManager = accounts[6];
+    const claimRegistryManagerIdentity = await ClaimHolder.new({ from: claimRegistryManager });
+
+    //should revert if sender is not claim registry manager
+    await ownerManager
+      .callRemoveClaimTopic(7, claimRegistryManagerIdentity.address, { from: claimRegistryManager })
+      .should.be.rejectedWith(EVMRevert);
+    let topic = await claimTopicsRegistry.getClaimTopics();
+    topic.length.should.equal(1);
+
+    //should add claim topic if sender is claim registry manager
+    await ownerManager.addClaimRegistryManager(claimRegistryManagerIdentity.address, { from: tokeny });
+    (await ownerManager.isClaimRegistryManager(claimRegistryManagerIdentity.address)).should.be.equal(true);
+    await ownerManager.callRemoveClaimTopic(7, claimRegistryManagerIdentity.address, { from: claimRegistryManager }).should.be.fulfilled;
+    topic = await claimTopicsRegistry.getClaimTopics();
+    topic.length.should.equal(0);
+  });
+
+  it('Should transfer ownership of contracts if called by admin', async () => {
+    const newOwner = accounts[6];
+    await ownerManager.callTransferOwnershipOnTokenContract(newOwner, { from: tokeny }).should.be.fulfilled;
+    (await token.owner()).should.equal(newOwner);
+    await ownerManager.callTransferOwnershipOnIdentityRegistryContract(newOwner, { from: tokeny }).should.be.fulfilled;
+    (await identityRegistry.owner()).should.equal(newOwner);
+    await ownerManager.callTransferOwnershipOnComplianceContract(newOwner, { from: tokeny }).should.be.fulfilled;
+    (await defaultCompliance.owner()).should.equal(newOwner);
+    await ownerManager.callTransferOwnershipOnClaimTopicsRegistryContract(newOwner, { from: tokeny }).should.be.fulfilled;
+    (await token.owner()).should.equal(newOwner);
+    await ownerManager.callTransferOwnershipOnIssuersRegistryContract(newOwner, { from: tokeny }).should.be.fulfilled;
+    (await token.owner()).should.equal(newOwner);
+  });
+
+  it('Should add and remove agent in token contract', async () => {
+    let newAgent = accounts[6];
+    await ownerManager.callAddAgentOnTokenContract(newAgent, { from: tokeny }).should.be.fulfilled;
+    (await token.isAgent(newAgent)).should.equal(true);
+    await ownerManager.callRemoveAgentOnTokenContract(newAgent, { from: tokeny }).should.be.fulfilled;
+    (await token.isAgent(newAgent)).should.equal(false);
+  });
+
+  it('Should add and remove agent in identity registry contract', async () => {
+    let newAgent = accounts[6];
+    await ownerManager.callAddAgentOnIdentityRegistryContract(newAgent, { from: tokeny }).should.be.fulfilled;
+    (await identityRegistry.isAgent(newAgent)).should.equal(true);
+    await ownerManager.callRemoveAgentOnIdentityRegistryContract(newAgent, { from: tokeny }).should.be.fulfilled;
+    (await identityRegistry.isAgent(newAgent)).should.equal(false);
+  });
+});

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -292,6 +292,23 @@ contract('TrustedIssuersRegistry', accounts => {
     await trustedIssuersRegistry.updateIssuerContract(1, trustedIssuer1.address, [2]).should.be.rejectedWith(EVMRevert);
   });
 
+  it('Should update claim topics if a trusted issuer exists', async () => {
+    await trustedIssuersRegistry.updateIssuerClaimTopics(1, [2, 7, 8]).should.be.fulfilled;
+    (await trustedIssuersRegistry.hasClaimTopic(trustedIssuer1.address, 1)).should.equal(false);
+    (await trustedIssuersRegistry.hasClaimTopic(trustedIssuer1.address, 2)).should.equal(true);
+    (await trustedIssuersRegistry.hasClaimTopic(trustedIssuer1.address, 7)).should.equal(true);
+    (await trustedIssuersRegistry.hasClaimTopic(trustedIssuer1.address, 8)).should.equal(true);
+  });
+
+  it('Should revert claim topics update if trusted issuer does not exist', async () => {
+    await trustedIssuersRegistry.updateIssuerClaimTopics(2, [2, 7, 8]).should.be.rejectedWith(EVMRevert);
+  });
+
+  it('Should revert claim topics update if claim topics set is empty', async () => {
+    await trustedIssuersRegistry.updateIssuerClaimTopics(1, []).should.be.rejectedWith(EVMRevert);
+    (await trustedIssuersRegistry.hasClaimTopic(trustedIssuer1.address, 1)).should.equal(true);
+  });
+
   it('Should return true if trusted issuer exists at an index', async () => {
     await trustedIssuersRegistry.getTrustedIssuer(1).should.be.fulfilled;
   });

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -1,7 +1,6 @@
 require('chai')
   .use(require('chai-as-promised'))
   .should();
-const log = require('./helpers/logger');
 const EVMRevert = require('./helpers/VMExceptionRevert');
 
 const ClaimTopicsRegistry = artifacts.require('../contracts/registry/ClaimTopicsRegistry.sol');
@@ -237,8 +236,6 @@ contract('TrustedIssuersRegistry', accounts => {
   it('Add trusted issuer should pass if valid credentials are provided', async () => {
     trustedIssuer2 = await IssuerIdentity.new({ from: accounts[2] });
     await trustedIssuersRegistry.addTrustedIssuer(trustedIssuer2.address, 2, [2]).should.be.fulfilled;
-    const issuers = await trustedIssuersRegistry.getTrustedIssuers();
-    log(`Issuers are: ${issuers}`);
   });
 
   it('Add trusted issuer should fail if invalid credentials are provided', async () => {
@@ -311,11 +308,6 @@ contract('TrustedIssuersRegistry', accounts => {
 
   it('Should return true if trusted issuer exists at an index', async () => {
     await trustedIssuersRegistry.getTrustedIssuer(1).should.be.fulfilled;
-  });
-
-  it('Should return claim topics if trusted issuer exist', async () => {
-    const claimTopics = await trustedIssuersRegistry.getTrustedIssuerClaimTopics(1);
-    log(`Claim topics ${claimTopics}`);
   });
 
   it('Should revert if no trusted issuer exist at given index', async () => {

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -62,7 +62,7 @@ contract('IdentityRegistry', accounts => {
     identityRegistry = await IdentityRegistry.new(trustedIssuersRegistry.address, claimTopicsRegistry.address, { from: accounts[0] });
     claimHolder = await ClaimHolder.new({ from: accounts[1] });
     claimHolder2 = await ClaimHolder.new({ from: accounts[2] });
-    await identityRegistry.addAgent(accounts[0]);
+    await identityRegistry.addAgentOnIdentityRegistryContract(accounts[0]);
     await identityRegistry.registerIdentity(accounts[1], claimHolder.address, 91);
   });
 
@@ -210,6 +210,14 @@ contract('IdentityRegistry', accounts => {
     registered6.toString().should.equal('true');
     registered7.toString().should.equal('true');
     registered8.toString().should.equal('true');
+  });
+
+  it('Should remove agent from identity registry contract', async () => {
+    let newAgent = accounts[3];
+    await identityRegistry.addAgentOnIdentityRegistryContract(newAgent, { from: accounts[0] }).should.be.fulfilled;
+    (await identityRegistry.isAgent(newAgent)).should.equal(true);
+    await identityRegistry.removeAgentOnIdentityRegistryContract(newAgent, { from: accounts[0] }).should.be.fulfilled;
+    (await identityRegistry.isAgent(newAgent)).should.equal(false);
   });
 });
 

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -213,7 +213,7 @@ contract('IdentityRegistry', accounts => {
   });
 
   it('Should remove agent from identity registry contract', async () => {
-    let newAgent = accounts[3];
+    const newAgent = accounts[3];
     await identityRegistry.addAgentOnIdentityRegistryContract(newAgent, { from: accounts[0] }).should.be.fulfilled;
     (await identityRegistry.isAgent(newAgent)).should.equal(true);
     await identityRegistry.removeAgentOnIdentityRegistryContract(newAgent, { from: accounts[0] }).should.be.fulfilled;

--- a/test/tokenTransfer.test.js
+++ b/test/tokenTransfer.test.js
@@ -452,7 +452,7 @@ contract('Token', accounts => {
 
   it('Token transfer fails if amount exceeds unfrozen tokens', async () => {
     await token.freezePartialTokens(user1, 800, { from: agent });
-    const frozenTokens2 = await token.frozenTokens(user1);
+    const frozenTokens2 = await token.getFrozenTokens(user1);
     frozenTokens2.toString().should.equal('800');
     await token.transfer(user2, 300, { from: user1 }).should.be.rejectedWith(EVMRevert);
     const balance1 = await token.balanceOf(user1);
@@ -461,9 +461,9 @@ contract('Token', accounts => {
 
   it('Tokens transfer after unfreezing tokens', async () => {
     await token.freezePartialTokens(user1, 800, { from: agent });
-    const frozenTokens1 = await token.frozenTokens(user1);
+    const frozenTokens1 = await token.getFrozenTokens(user1);
     await token.unfreezePartialTokens(user1, 500, { from: agent });
-    const frozenTokens2 = await token.frozenTokens(user1);
+    const frozenTokens2 = await token.getFrozenTokens(user1);
 
     await token.transfer(user2, 300, { from: user1 }).should.be.fulfilled;
 
@@ -538,7 +538,7 @@ contract('Token', accounts => {
   it('Transfer from fails if amount exceeds unfrozen tokens', async () => {
     const balance1 = await token.balanceOf(user1);
     await token.freezePartialTokens(user1, 800, { from: agent });
-    const frozenTokens2 = await token.frozenTokens(user1);
+    const frozenTokens2 = await token.getFrozenTokens(user1);
     await token.approve(accounts[4], 300, { from: user1 }).should.be.fulfilled;
     await token.transferFrom(user1, user2, 300, { from: accounts[4] }).should.be.rejectedWith(EVMRevert);
     const balance2 = await token.balanceOf(user1);
@@ -549,9 +549,9 @@ contract('Token', accounts => {
 
   it('Transfer from passes after unfreezing tokens', async () => {
     await token.freezePartialTokens(user1, 800, { from: agent });
-    const frozenTokens1 = await token.frozenTokens(user1);
+    const frozenTokens1 = await token.getFrozenTokens(user1);
     await token.unfreezePartialTokens(user1, 500, { from: agent });
-    const frozenTokens2 = await token.frozenTokens(user1);
+    const frozenTokens2 = await token.getFrozenTokens(user1);
     await token.approve(accounts[4], 300, { from: user1 }).should.be.fulfilled;
     await token.transferFrom(user1, user2, 300, { from: accounts[4] }).should.be.fulfilled;
     const balance = await token.balanceOf(user1);
@@ -663,7 +663,7 @@ contract('Token', accounts => {
     await token.forcedTransfer(user1, user2, 300, { from: agent }).should.be.fulfilled;
     const balance1 = await token.balanceOf(user1);
     const balance2 = await token.balanceOf(user2);
-    const frozenTokens1 = await token.frozenTokens(user1);
+    const frozenTokens1 = await token.getFrozenTokens(user1);
     balance1.toString().should.equal('700');
     balance2.toString().should.equal('300');
     frozenTokens1.toString().should.equal('700');
@@ -808,7 +808,6 @@ contract('Token', accounts => {
     await identityRegistry.registerIdentity(user3, user3Contract.address, 91, {
       from: agent,
     }).should.be.fulfilled;
-    // user1 adds claim to identity contract
     await user3Contract.addClaim(7, 1, claimIssuerContract.address, signature3, hexedData3, '', { from: user3 });
     await token
       .batchForcedTransfer([user1, user1], [user2, user3], [300, 200], {
@@ -852,8 +851,8 @@ contract('Token', accounts => {
     await token.batchFreezePartialTokens([user1, user2], [200, 200], {
       from: agent,
     });
-    const frozenTokens1 = await token.frozenTokens(user1);
-    const frozenTokens2 = await token.frozenTokens(user2);
+    const frozenTokens1 = await token.getFrozenTokens(user1);
+    const frozenTokens2 = await token.getFrozenTokens(user2);
     frozenTokens1.toString().should.equal('200');
     frozenTokens2.toString().should.equal('200');
     await token.transfer(user1, 300, { from: user2 }).should.be.rejectedWith(EVMRevert);
@@ -872,8 +871,8 @@ contract('Token', accounts => {
         from: agent,
       },
     );
-    const frozenTokens1 = await token.frozenTokens(user1);
-    const frozenTokens2 = await token.frozenTokens(user2);
+    const frozenTokens1 = await token.getFrozenTokens(user1);
+    const frozenTokens2 = await token.getFrozenTokens(user2);
     frozenTokens1.toString().should.equal('200');
     frozenTokens2.toString().should.equal('200');
     await token.transfer(user1, 300, { from: user2 }).should.be.rejectedWith(EVMRevert);
@@ -890,8 +889,8 @@ contract('Token', accounts => {
         from: user1,
       })
       .should.be.rejectedWith(EVMRevert);
-    const frozenTokens1 = await token.frozenTokens(user1);
-    const frozenTokens2 = await token.frozenTokens(user2);
+    const frozenTokens1 = await token.getFrozenTokens(user1);
+    const frozenTokens2 = await token.getFrozenTokens(user2);
     frozenTokens1.toString().should.equal('0');
     frozenTokens2.toString().should.equal('0');
     await token.transfer(user1, 300, { from: user2 }).should.be.fulfilled;
@@ -909,8 +908,8 @@ contract('Token', accounts => {
     await token.batchUnfreezePartialTokens([user1, user2], [200, 200], {
       from: agent,
     });
-    const frozenTokens1 = await token.frozenTokens(user1);
-    const frozenTokens2 = await token.frozenTokens(user2);
+    const frozenTokens1 = await token.getFrozenTokens(user1);
+    const frozenTokens2 = await token.getFrozenTokens(user2);
     frozenTokens1.toString().should.equal('0');
     frozenTokens2.toString().should.equal('0');
   });
@@ -927,8 +926,8 @@ contract('Token', accounts => {
         from: agent,
       },
     );
-    const frozenTokens1 = await token.frozenTokens(user1);
-    const frozenTokens2 = await token.frozenTokens(user2);
+    const frozenTokens1 = await token.getFrozenTokens(user1);
+    const frozenTokens2 = await token.getFrozenTokens(user2);
     frozenTokens1.toString().should.equal('0');
     frozenTokens2.toString().should.equal('0');
   });
@@ -943,15 +942,13 @@ contract('Token', accounts => {
         from: user1,
       })
       .should.be.rejectedWith(EVMRevert);
-    const frozenTokens1 = await token.frozenTokens(user1);
-    const frozenTokens2 = await token.frozenTokens(user2);
+    const frozenTokens1 = await token.getFrozenTokens(user1);
+    const frozenTokens2 = await token.getFrozenTokens(user2);
     frozenTokens1.toString().should.equal('200');
     frozenTokens2.toString().should.equal('200');
     await token.transfer(user1, 100, { from: user2 }).should.be.fulfilled;
     await token.transfer(user1, 100, { from: user2 }).should.be.rejectedWith(EVMRevert);
-    // transfer tokens that are not frozen
     const balance1 = await token.balanceOf(user1);
-    // try to transfer more tokens
     const balance2 = await token.balanceOf(user2);
     balance1.toString().should.equal('800');
     balance2.toString().should.equal('200');

--- a/test/tokenTransfer.test.js
+++ b/test/tokenTransfer.test.js
@@ -141,6 +141,37 @@ contract('Token', accounts => {
     onchainID1.toString().should.equal(tokenOnchainID.address);
   });
 
+  it('totalSupply returns the total supply of the token', async () => {
+    const totalSupply = await token.totalSupply().should.be.fulfilled;
+    totalSupply.toString().should.equal('1000');
+  });
+
+  it('should get compliance address for the token', async () => {
+    const compliance = await token.getCompliance().should.be.fulfilled;
+    compliance.should.equal(defaultCompliance.address);
+  });
+
+  it('allowance returns the approved amount of tokens', async () => {
+	await token.approve('0x0000000000000000000000000000000000000000', 500, {from: user1}).should.be.rejectedWith(EVMRevert);
+	await token.approve(user2, 500, {from: user1}).should.be.fulfilled;
+	const allowance = await token.allowance(user1, user2).should.be.fulfilled;
+    allowance.toString().should.equal('500');
+  });
+
+  it('should increase allowance by the amount of tokens given', async () => {	
+	await token.approve(user2, 500, {from: user1}).should.be.fulfilled;
+	await token.increaseAllowance(user2, 100, {from: user1});
+	const allowance = await token.allowance(user1, user2).should.be.fulfilled;
+    allowance.toString().should.equal('600');
+  });
+
+  it('should decrease allowance by the amount of tokens given', async () => {
+	await token.approve(user2, 500, {from: user1}).should.be.fulfilled;
+	await token.decreaseAllowance(user2, 100, {from: user1});
+	const allowance = await token.allowance(user1, user2).should.be.fulfilled;
+    allowance.toString().should.equal('400');
+  });
+
   it('Successful Token transfer', async () => {
     await token.transfer(user2, 300, { from: user1 }).should.be.fulfilled;
     const balance1 = await token.balanceOf(user1);

--- a/test/tokenTransfer.test.js
+++ b/test/tokenTransfer.test.js
@@ -152,28 +152,28 @@ contract('Token', accounts => {
   });
 
   it('allowance returns the approved amount of tokens', async () => {
-	await token.approve('0x0000000000000000000000000000000000000000', 500, {from: user1}).should.be.rejectedWith(EVMRevert);
-	await token.approve(user2, 500, {from: user1}).should.be.fulfilled;
-	const allowance = await token.allowance(user1, user2).should.be.fulfilled;
+    await token.approve('0x0000000000000000000000000000000000000000', 500, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    await token.approve(user2, 500, { from: user1 }).should.be.fulfilled;
+    const allowance = await token.allowance(user1, user2).should.be.fulfilled;
     allowance.toString().should.equal('500');
   });
 
-  it('should increase allowance by the amount of tokens given', async () => {	
-	await token.approve(user2, 500, {from: user1}).should.be.fulfilled;
-	await token.increaseAllowance(user2, 100, {from: user1});
-	const allowance = await token.allowance(user1, user2).should.be.fulfilled;
+  it('should increase allowance by the amount of tokens given', async () => {
+    await token.approve(user2, 500, { from: user1 }).should.be.fulfilled;
+    await token.increaseAllowance(user2, 100, { from: user1 });
+    const allowance = await token.allowance(user1, user2).should.be.fulfilled;
     allowance.toString().should.equal('600');
   });
 
   it('should decrease allowance by the amount of tokens given', async () => {
-	await token.approve(user2, 500, {from: user1}).should.be.fulfilled;
-	await token.decreaseAllowance(user2, 100, {from: user1});
-	const allowance = await token.allowance(user1, user2).should.be.fulfilled;
+    await token.approve(user2, 500, { from: user1 }).should.be.fulfilled;
+    await token.decreaseAllowance(user2, 100, { from: user1 });
+    const allowance = await token.allowance(user1, user2).should.be.fulfilled;
     allowance.toString().should.equal('400');
   });
 
   it('Successful Token transfer', async () => {
-    //should revert if receiver is zero address
+    // should revert if receiver is zero address
     await token.transfer('0x0000000000000000000000000000000000000000', 300, { from: user1 }).should.be.rejectedWith(EVMRevert);
 
     await token.transfer(user2, 300, { from: user1 }).should.be.fulfilled;
@@ -184,7 +184,7 @@ contract('Token', accounts => {
   });
 
   it('Successful Burn the tokens', async () => {
-    //should revert if zero address given
+    // should revert if zero address given
     await token.burn('0x0000000000000000000000000000000000000000', 300, { from: agent }).should.be.rejectedWith(EVMRevert);
 
     await token.burn(user1, 300, { from: agent }).should.be.fulfilled;
@@ -194,7 +194,7 @@ contract('Token', accounts => {
   });
 
   it('Should remove agent from token contract', async () => {
-    let newAgent = accounts[5];
+    const newAgent = accounts[5];
     await token.addAgentOnTokenContract(newAgent, { from: tokeny }).should.be.fulfilled;
     (await token.isAgent(newAgent)).should.equal(true);
     await token.removeAgentOnTokenContract(newAgent, { from: tokeny }).should.be.fulfilled;
@@ -489,7 +489,7 @@ contract('Token', accounts => {
   });
 
   it('Successfuly transfers Token if sender approved', async () => {
-    //should revert if zero address
+    // should revert if zero address
     await token.approve('0x0000000000000000000000000000000000000000', 300, { from: user1 }).should.be.rejectedWith(EVMRevert);
 
     await token.approve(accounts[4], 300, { from: user1 }).should.be.fulfilled;


### PR DESCRIPTION
those smart contracts are intended to be used to increase granularity of the agent/owner roles, as the roles described at token level could be too permissive and as the role's permissions are hardcoded in the token smart contracts and not modifiable post-deployment, these external smart contracts could be used easily to change the permissions of a role, and a custom version of this smart contract could also be created in case there is a need for even more granularity in the role's permissions. By setting this smart contract as agent/owner on the smart contracts it allows to get more granularity on the permissions linked to the different roles and it also allows to link these roles to the onchainID of the agent/owner which prevent him from losing access to the functions if he loose his private key (as it is recommanded to have several management keys on the onchainID) 