### PR TITLE
External owner manager

### DIFF
--- a/contracts/compliance/DefaultCompliance.sol
+++ b/contracts/compliance/DefaultCompliance.sol
@@ -1,8 +1,9 @@
 pragma solidity ^0.6.0;
 
 import "./ICompliance.sol";
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
-contract DefaultCompliance is ICompliance {
+contract DefaultCompliance is ICompliance, Ownable {
 
     /**
     * @notice checks that the transfer is compliant.
@@ -26,6 +27,10 @@ contract DefaultCompliance is ICompliance {
 
     function destroyed(address _from, uint256 _value) public override returns (bool) {
         return true;
+    }
+
+    function transferOwnershipOnComplianceContract(address newOwner) external override onlyOwner {
+        transferOwnership(newOwner);
     }
 }
 

--- a/contracts/compliance/ICompliance.sol
+++ b/contracts/compliance/ICompliance.sol
@@ -5,4 +5,7 @@ interface ICompliance {
     function transferred(address _from, address _to, uint256 _value) external returns (bool);
     function created(address _to, uint256 _value) external returns (bool);
     function destroyed(address _from, uint256 _value) external returns (bool);
+
+    // transfer contract ownership
+    function transferOwnershipOnComplianceContract(address newOwner) external;
 }

--- a/contracts/compliance/LimitHolder.sol
+++ b/contracts/compliance/LimitHolder.sol
@@ -119,4 +119,8 @@ contract LimitHolder is ICompliance, AgentRole {
         pruneShareholders(_from, _value);
         return true;
     }
+
+    function transferOwnershipOnComplianceContract(address newOwner) external override onlyOwner {
+        transferOwnership(newOwner);
+    }
 }

--- a/contracts/registry/ClaimTopicsRegistry.sol
+++ b/contracts/registry/ClaimTopicsRegistry.sol
@@ -49,4 +49,8 @@ contract ClaimTopicsRegistry is IClaimTopicsRegistry, Ownable {
     function getClaimTopics() public override view returns (uint256[] memory) {
         return claimTopics;
     }
+
+    function transferOwnershipOnClaimTopicsRegistryContract(address newOwner) external override onlyOwner {
+        transferOwnership(newOwner);
+    }
 }

--- a/contracts/registry/IClaimTopicsRegistry.sol
+++ b/contracts/registry/IClaimTopicsRegistry.sol
@@ -11,4 +11,7 @@ interface IClaimTopicsRegistry{
 
     // GETTERS
     function getClaimTopics() external view returns (uint256[] memory);
+
+    // transfer contract ownership
+    function transferOwnershipOnClaimTopicsRegistryContract(address newOwner) external;
 }

--- a/contracts/registry/IIdentityRegistry.sol
+++ b/contracts/registry/IIdentityRegistry.sol
@@ -33,4 +33,7 @@ interface IIdentityRegistry {
     function getInvestorCountryOfWallet(address _wallet) external view returns (uint16);
     function getIssuersRegistry() external view returns (ITrustedIssuersRegistry);
     function getTopicsRegistry() external view returns (IClaimTopicsRegistry);
+
+    // transfer contract ownership
+    function transferOwnershipOnIdentityRegistryContract(address newOwner) external;
 }

--- a/contracts/registry/IIdentityRegistry.sol
+++ b/contracts/registry/IIdentityRegistry.sol
@@ -36,4 +36,8 @@ interface IIdentityRegistry {
 
     // transfer contract ownership
     function transferOwnershipOnIdentityRegistryContract(address newOwner) external;
+
+    // manage Agent Role (onlyOwner functions)
+    function addAgentOnIdentityRegistryContract(address agent) external;
+    function removeAgentOnIdentityRegistryContract(address agent) external;
 }

--- a/contracts/registry/ITrustedIssuersRegistry.sol
+++ b/contracts/registry/ITrustedIssuersRegistry.sol
@@ -19,4 +19,7 @@ interface ITrustedIssuersRegistry {
     function addTrustedIssuer(IClaimIssuer _trustedIssuer, uint index, uint[] calldata claimTopics) external;
     function removeTrustedIssuer(uint index) external;
     function updateIssuerContract(uint index, IClaimIssuer _newTrustedIssuer, uint[] calldata claimTopics) external;
+
+    // transfer contract ownership
+    function transferOwnershipOnIssuersRegistryContract(address newOwner) external;
 }

--- a/contracts/registry/IdentityRegistry.sol
+++ b/contracts/registry/IdentityRegistry.sol
@@ -217,4 +217,13 @@ contract IdentityRegistry is IIdentityRegistry, AgentRole {
     function transferOwnershipOnIdentityRegistryContract(address newOwner) external override onlyOwner {
         transferOwnership(newOwner);
     }
+
+    function addAgentOnIdentityRegistryContract(address agent) external override {
+        addAgent(agent);
+    }
+
+    function removeAgentOnIdentityRegistryContract(address agent) external override {
+        removeAgent(agent);
+    }
+
 }

--- a/contracts/registry/IdentityRegistry.sol
+++ b/contracts/registry/IdentityRegistry.sol
@@ -213,4 +213,8 @@ contract IdentityRegistry is IIdentityRegistry, AgentRole {
 
         return true;
     }
+
+    function transferOwnershipOnIdentityRegistryContract(address newOwner) external override onlyOwner {
+        transferOwnership(newOwner);
+    }
 }

--- a/contracts/registry/TrustedIssuersRegistry.sol
+++ b/contracts/registry/TrustedIssuersRegistry.sol
@@ -187,4 +187,8 @@ contract TrustedIssuersRegistry is ITrustedIssuersRegistry, Ownable {
 
         emit TrustedIssuerUpdated(index, trustedIssuers[index], _newTrustedIssuer, claimTopics);
     }
+
+    function transferOwnershipOnIssuersRegistryContract(address newOwner) external override onlyOwner {
+        transferOwnership(newOwner);
+    }
 }

--- a/contracts/roles/AgentManager.sol
+++ b/contracts/roles/AgentManager.sol
@@ -20,6 +20,11 @@ contract AgentManager is AgentRoles {
         token.forcedTransfer(_from, _to, _value);
     }
 
+    function callBatchForcedTransfer(address[] calldata _fromList, address[] calldata _toList, uint256[] calldata _values, IIdentity onchainID) external {
+        require(isTransferManager(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Transfer Manager");
+        token.batchForcedTransfer(_fromList, _toList, _values);
+    }
+
     function callPause(IIdentity onchainID) external {
         require(isFreezer(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Freezer");
         token.pause();
@@ -35,9 +40,19 @@ contract AgentManager is AgentRoles {
         token.mint(_to, _amount);
     }
 
+    function callBatchMint(address[] calldata _toList, uint256[] calldata _amounts, IIdentity onchainID) external {
+        require(isSupplyModifier(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Supply Modifier");
+        token.batchMint(_toList, _amounts);
+    }
+
     function callBurn(address account, uint256 value, IIdentity onchainID) external {
         require(isSupplyModifier(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Supply Modifier");
-        token.mint(account, value);
+        token.burn(account, value);
+    }
+
+    function callBatchBurn(address[] calldata accounts, uint256[] calldata values, IIdentity onchainID) external {
+        require(isSupplyModifier(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Supply Modifier");
+        token.batchBurn(accounts, values);
     }
 
     function callSetAddressFrozen(address addr, bool freeze, IIdentity onchainID) external {
@@ -45,14 +60,29 @@ contract AgentManager is AgentRoles {
         token.setAddressFrozen(addr, freeze);
     }
 
+    function callBatchSetAddressFrozen(address[] calldata addrList, bool[] calldata freeze, IIdentity onchainID) external {
+        require(isFreezer(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Freezer");
+        token.batchSetAddressFrozen(addrList, freeze);
+    }
+
     function callFreezePartialTokens(address addr, uint256 amount, IIdentity onchainID) external {
         require(isFreezer(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Freezer");
         token.freezePartialTokens(addr, amount);
     }
 
+    function callBatchFreezePartialTokens(address[] calldata addrList, uint256[] calldata amounts, IIdentity onchainID) external {
+        require(isFreezer(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Freezer");
+        token.batchFreezePartialTokens(addrList, amounts);
+    }
+
     function callUnfreezePartialTokens(address addr, uint256 amount, IIdentity onchainID) external {
         require(isFreezer(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Freezer");
         token.unfreezePartialTokens(addr, amount);
+    }
+
+    function callBatchUnfreezePartialTokens(address[] calldata addrList, uint256[] calldata amounts, IIdentity onchainID) external {
+        require(isFreezer(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Freezer");
+        token.batchUnfreezePartialTokens(addrList, amounts);
     }
 
     function callRecoveryAddress(address wallet_lostAddress, address wallet_newAddress, address investorOnchainID, IIdentity onchainID) external {

--- a/contracts/roles/AgentManager.sol
+++ b/contracts/roles/AgentManager.sol
@@ -12,7 +12,6 @@ contract AgentManager is AgentRoles {
 
     constructor (address _token) public {
         token = IToken(_token);
-        identityRegistry = token.getIdentityRegistry();
     }
 
     function callForcedTransfer(address _from, address _to, uint256 _value, IIdentity onchainID) external {
@@ -92,21 +91,25 @@ contract AgentManager is AgentRoles {
 
     function callRegisterIdentity(address _user, IIdentity _identity, uint16 _country, IIdentity onchainID) external {
         require(isWhiteListManager(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT WhiteList Manager");
+        identityRegistry = token.getIdentityRegistry();
         identityRegistry.registerIdentity(_user, _identity, _country);
     }
 
     function callUpdateIdentity(address _user, IIdentity _identity, IIdentity onchainID) external {
         require(isWhiteListManager(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT WhiteList Manager");
+        identityRegistry = token.getIdentityRegistry();
         identityRegistry.updateIdentity(_user, _identity);
     }
 
     function callUpdateCountry(address _user, uint16 _country, IIdentity onchainID) external {
         require(isWhiteListManager(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT WhiteList Manager");
+        identityRegistry = token.getIdentityRegistry();
         identityRegistry.updateCountry(_user, _country);
     }
 
     function callDeleteIdentity(address _user, IIdentity onchainID) external {
         require(isWhiteListManager(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT WhiteList Manager");
+        identityRegistry = token.getIdentityRegistry();
         identityRegistry.deleteIdentity(_user);
     }
 }

--- a/contracts/roles/OwnerManager.sol
+++ b/contracts/roles/OwnerManager.sol
@@ -1,0 +1,112 @@
+pragma solidity ^0.6.0;
+
+import "../token/IToken.sol";
+import "../registry/IIdentityRegistry.sol";
+import "../registry/ITrustedIssuersRegistry.sol";
+import "../registry/IClaimTopicsRegistry.sol";
+import "../compliance/ICompliance.sol";
+import "./OwnerRoles.sol";
+import "@onchain-id/solidity/contracts/IIdentity.sol";
+import "@onchain-id/solidity/contracts/IClaimIssuer.sol";
+
+contract OwnerManager is OwnerRoles {
+
+    IToken public token;
+    IIdentityRegistry public identityRegistry;
+    ITrustedIssuersRegistry public issuersRegistry;
+    IClaimTopicsRegistry public topicsRegistry;
+    ICompliance public compliance;
+
+
+    constructor (address _token) public {
+        token = IToken(_token);
+    }
+
+    function callSetIdentityRegistry(address _identityRegistry, IIdentity onchainID) external {
+        require(isRegistryAddressSetter(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Registry Address Setter");
+        token.setIdentityRegistry(_identityRegistry);
+    }
+
+    function callSetCompliance(address _compliance, IIdentity onchainID) external {
+        require(isComplianceSetter(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Compliance Setter");
+        token.setCompliance(_compliance);
+    }
+
+    function callSetTokenInformation(string calldata _name, string calldata _symbol, uint8 _decimals, string calldata _version, address _onchainID, IIdentity onchainID) external {
+        require(isTokenInfoManager(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Token Information Manager");
+        token.setTokenInformation(_name, _symbol, _decimals, _version, _onchainID);
+    }
+
+    function callSetClaimTopicsRegistry(address _claimTopicsRegistry, IIdentity onchainID) external {
+        require(isRegistryAddressSetter(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Registry Address Setter");
+        identityRegistry = token.getIdentityRegistry();
+        identityRegistry.setClaimTopicsRegistry(_claimTopicsRegistry);
+    }
+
+    function callSetTrustedIssuersRegistry(address _trustedIssuersRegistry, IIdentity onchainID) external {
+        require(isRegistryAddressSetter(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Registry Address Setter");
+        identityRegistry = token.getIdentityRegistry();
+        identityRegistry.setTrustedIssuersRegistry(_trustedIssuersRegistry);
+    }
+
+    function callAddTrustedIssuer(IClaimIssuer _trustedIssuer, uint index, uint[] calldata claimTopics, IIdentity onchainID) external {
+        require(isIssuersRegistryManager(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT IssuersRegistryManager");
+        identityRegistry = token.getIdentityRegistry();
+        issuersRegistry = identityRegistry.getIssuersRegistry();
+        issuersRegistry.addTrustedIssuer(_trustedIssuer, index, claimTopics);
+    }
+
+    function callRemoveTrustedIssuer(uint index, IIdentity onchainID) external {
+        require(isIssuersRegistryManager(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT IssuersRegistryManager");
+        identityRegistry = token.getIdentityRegistry();
+        issuersRegistry = identityRegistry.getIssuersRegistry();
+        issuersRegistry.removeTrustedIssuer(index);
+    }
+
+    function callUpdateIssuerContract(uint index, IClaimIssuer _newTrustedIssuer, uint[] calldata claimTopics, IIdentity onchainID) external {
+        require(isIssuersRegistryManager(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT IssuersRegistryManager");
+        identityRegistry = token.getIdentityRegistry();
+        issuersRegistry = identityRegistry.getIssuersRegistry();
+        issuersRegistry.updateIssuerContract(index, _newTrustedIssuer, claimTopics);
+    }
+
+    function callAddClaimTopic(uint256 claimTopic, IIdentity onchainID) external {
+        require(isClaimRegistryManager(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT ClaimRegistryManager");
+        identityRegistry = token.getIdentityRegistry();
+        topicsRegistry = identityRegistry.getTopicsRegistry();
+        topicsRegistry.addClaimTopic(claimTopic);
+    }
+
+    function callRemoveClaimTopic(uint256 claimTopic, IIdentity onchainID) external {
+        require(isClaimRegistryManager(address(onchainID)) && onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT ClaimRegistryManager");
+        identityRegistry = token.getIdentityRegistry();
+        topicsRegistry = identityRegistry.getTopicsRegistry();
+        topicsRegistry.removeClaimTopic(claimTopic);
+    }
+
+    function callTransferOwnershipOnTokenContract(address newOwner) external onlyAdmin {
+        token.transferOwnershipOnTokenContract(newOwner);
+    }
+
+    function callTransferOwnershipOnIdentityRegistryContract(address newOwner) external onlyAdmin {
+        identityRegistry = token.getIdentityRegistry();
+        identityRegistry.transferOwnershipOnIdentityRegistryContract(newOwner);
+    }
+
+    function callTransferOwnershipOnComplianceContract(address newOwner) external onlyAdmin {
+        compliance = token.getCompliance();
+        compliance.transferOwnershipOnComplianceContract(newOwner);
+    }
+
+    function callTransferOwnershipOnClaimTopicsRegistryContract(address newOwner) external onlyAdmin {
+        identityRegistry = token.getIdentityRegistry();
+        topicsRegistry = identityRegistry.getTopicsRegistry();
+        topicsRegistry.transferOwnershipOnClaimTopicsRegistryContract(newOwner);
+    }
+
+    function callTransferOwnershipOnIssuersRegistryContract(address newOwner) external onlyAdmin {
+        identityRegistry = token.getIdentityRegistry();
+        issuersRegistry = identityRegistry.getIssuersRegistry();
+        issuersRegistry.transferOwnershipOnIssuersRegistryContract(newOwner);
+    }
+}

--- a/contracts/roles/OwnerManager.sol
+++ b/contracts/roles/OwnerManager.sol
@@ -109,4 +109,22 @@ contract OwnerManager is OwnerRoles {
         issuersRegistry = identityRegistry.getIssuersRegistry();
         issuersRegistry.transferOwnershipOnIssuersRegistryContract(newOwner);
     }
+
+    function callAddAgentOnTokenContract(address agent) external onlyAdmin {
+        token.addAgentOnTokenContract(agent);
+    }
+
+    function callRemoveAgentOnTokenContract(address agent) external onlyAdmin {
+        token.removeAgentOnTokenContract(agent);
+    }
+
+    function callAddAgentOnIdentityRegistryContract(address agent) external onlyAdmin {
+        identityRegistry = token.getIdentityRegistry();
+        identityRegistry.addAgentOnIdentityRegistryContract(agent);
+    }
+
+    function callRemoveAgentOnIdentityRegistryContract(address agent) external onlyAdmin {
+        identityRegistry = token.getIdentityRegistry();
+        identityRegistry.removeAgentOnIdentityRegistryContract(agent);
+    }
 }

--- a/contracts/roles/OwnerRoles.sol
+++ b/contracts/roles/OwnerRoles.sol
@@ -1,0 +1,131 @@
+pragma solidity ^0.6.0;
+
+import "openzeppelin-solidity/contracts/access/Roles.sol";
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+
+contract OwnerRoles is Ownable {
+    using Roles for Roles.Role;
+
+    event RoleAdded(address indexed account, string role);
+    event RoleRemoved(address indexed account, string role);
+
+    Roles.Role private _ownerAdmin;
+    Roles.Role private _registryAddressSetter;
+    Roles.Role private _complianceSetter;
+    Roles.Role private _claimRegistryManager;
+    Roles.Role private _issuersRegistryManager;
+    Roles.Role private _tokenInfoManager;
+
+modifier onlyAdmin() {
+        require(isOwner() || isOwnerAdmin(_msgSender()), "Role: Sender is NOT Admin");
+        _;
+    }
+
+    // OwnerAdmin Role _ownerAdmin
+
+    function isOwnerAdmin(address account) public view returns (bool) {
+        return _ownerAdmin.has(account);
+    }
+
+    function addOwnerAdmin(address account) public onlyAdmin {
+        _ownerAdmin.add(account);
+        string memory role = "OwnerAdmin";
+        emit RoleAdded(account, role);
+    }
+
+    function removeOwnerAdmin(address account) public onlyAdmin {
+        _ownerAdmin.remove(account);
+        string memory role = "OwnerAdmin";
+        emit RoleRemoved(account, role);
+    }
+
+    // RegistryAddressSetter Role _registryAddressSetter
+
+    function isRegistryAddressSetter(address account) public view returns (bool) {
+        return _registryAddressSetter.has(account);
+    }
+
+    function addRegistryAddressSetter(address account) public onlyAdmin {
+        _registryAddressSetter.add(account);
+        string memory role = "RegistryAddressSetter";
+        emit RoleAdded(account, role);
+    }
+
+    function removeRegistryAddressSetter(address account) public onlyAdmin {
+        _registryAddressSetter.remove(account);
+        string memory role = "RegistryAddressSetter";
+        emit RoleRemoved(account, role);
+    }
+
+    // ComplianceSetter Role _complianceSetter
+
+    function isComplianceSetter(address account) public view returns (bool) {
+        return _complianceSetter.has(account);
+    }
+
+    function addComplianceSetter(address account) public onlyAdmin {
+        _complianceSetter.add(account);
+        string memory role = "ComplianceSetter";
+        emit RoleAdded(account, role);
+    }
+
+    function removeComplianceSetter(address account) public onlyAdmin {
+        _complianceSetter.remove(account);
+        string memory role = "ComplianceSetter";
+        emit RoleRemoved(account, role);
+    }
+
+    // ClaimRegistryManager Role _claimRegistryManager
+
+    function isClaimRegistryManager(address account) public view returns (bool) {
+        return _claimRegistryManager.has(account);
+    }
+
+    function addClaimRegistryManager(address account) public onlyAdmin {
+        _claimRegistryManager.add(account);
+        string memory role = "ClaimRegistryManager";
+        emit RoleAdded(account, role);
+    }
+
+    function removeClaimRegistryManager(address account) public onlyAdmin {
+        _claimRegistryManager.remove(account);
+        string memory role = "ClaimRegistryManager";
+        emit RoleRemoved(account, role);
+    }
+
+    // IssuersRegistryManager Role _issuersRegistryManager
+
+    function isIssuersRegistryManager(address account) public view returns (bool) {
+        return _issuersRegistryManager.has(account);
+    }
+
+    function addIssuersRegistryManager(address account) public onlyAdmin {
+        _issuersRegistryManager.add(account);
+        string memory role = "IssuersRegistryManager";
+        emit RoleAdded(account, role);
+    }
+
+    function removeIssuersRegistryManager(address account) public onlyAdmin {
+        _issuersRegistryManager.remove(account);
+        string memory role = "IssuersRegistryManager";
+        emit RoleRemoved(account, role);
+    }
+
+    // TokenInfoManager Role _tokenInfoManager
+
+    function isTokenInfoManager(address account) public view returns (bool) {
+        return _tokenInfoManager.has(account);
+    }
+
+    function addTokenInfoManager(address account) public onlyAdmin {
+        _tokenInfoManager.add(account);
+        string memory role = "TokenInfoManager";
+        emit RoleAdded(account, role);
+    }
+
+    function removeTokenInfoManager(address account) public onlyAdmin {
+        _tokenInfoManager.remove(account);
+        string memory role = "TokenInfoManager";
+        emit RoleRemoved(account, role);
+    }
+}

--- a/contracts/roles/OwnerRoles.sol
+++ b/contracts/roles/OwnerRoles.sol
@@ -16,7 +16,7 @@ contract OwnerRoles is Ownable {
     Roles.Role private _issuersRegistryManager;
     Roles.Role private _tokenInfoManager;
 
-modifier onlyAdmin() {
+    modifier onlyAdmin() {
         require(isOwner() || isOwnerAdmin(_msgSender()), "Role: Sender is NOT Admin");
         _;
     }

--- a/contracts/token/IToken.sol
+++ b/contracts/token/IToken.sol
@@ -5,7 +5,7 @@ import "../registry/IIdentityRegistry.sol";
 import "../compliance/ICompliance.sol";
 
 //interface
-interface IToken is IERC20{
+interface IToken is IERC20 {
     event UpdatedTokenInformation(string newName, string newSymbol, uint8 newDecimals, string newVersion, address newOnchainID);
 
     // getters
@@ -41,4 +41,7 @@ interface IToken is IERC20{
     function batchSetAddressFrozen(address[] calldata addrList, bool[] calldata freeze) external;
     function batchFreezePartialTokens(address[] calldata addrList, uint256[] calldata amounts) external;
     function batchUnfreezePartialTokens(address[] calldata addrList, uint256[] calldata amounts) external;
+
+    // transfer contract ownership
+    function transferOwnershipOnTokenContract(address newOwner) external;
 }

--- a/contracts/token/IToken.sol
+++ b/contracts/token/IToken.sol
@@ -44,4 +44,9 @@ interface IToken is IERC20 {
 
     // transfer contract ownership
     function transferOwnershipOnTokenContract(address newOwner) external;
+
+    // manage Agent Role (onlyOwner functions)
+    function addAgentOnTokenContract(address agent) external;
+    function removeAgentOnTokenContract(address agent) external;
+
 }

--- a/contracts/token/IToken.sol
+++ b/contracts/token/IToken.sol
@@ -36,8 +36,8 @@ interface IToken is IERC20{
     function recoveryAddress(address lostWallet, address newWallet, address investorOnchainID) external returns (bool);
     function batchTransfer(address[] calldata _toList, uint256[] calldata _values) external;
     function batchForcedTransfer(address[] calldata _fromList, address[] calldata _toList, uint256[] calldata _values) external;
-    function batchMint(address[] calldata _to, uint256[] calldata _amount) external;
-    function batchBurn(address[] calldata account, uint256[] calldata value) external;
+    function batchMint(address[] calldata _toList, uint256[] calldata _amounts) external;
+    function batchBurn(address[] calldata accounts, uint256[] calldata values) external;
     function batchSetAddressFrozen(address[] calldata addrList, bool[] calldata freeze) external;
     function batchFreezePartialTokens(address[] calldata addrList, uint256[] calldata amounts) external;
     function batchUnfreezePartialTokens(address[] calldata addrList, uint256[] calldata amounts) external;

--- a/contracts/token/Token.sol
+++ b/contracts/token/Token.sol
@@ -531,9 +531,9 @@ contract Token is IToken, Context, AgentRole {
         compliance.created(_to, _amount);
     }
 
-    function batchMint(address[] calldata _to, uint256[] calldata _amount) external override {
-        for (uint256 i = 0; i < _to.length; i++) {
-            mint(_to[i], _amount[i]);
+    function batchMint(address[] calldata _toList, uint256[] calldata _amounts) external override {
+        for (uint256 i = 0; i < _toList.length; i++) {
+            mint(_toList[i], _amounts[i]);
         }
     }
 
@@ -542,9 +542,9 @@ contract Token is IToken, Context, AgentRole {
         compliance.destroyed(account, value);
     }
 
-    function batchBurn(address[] calldata account, uint256[] calldata value) external override {
-        for (uint256 i = 0; i < account.length; i++) {
-            burn(account[i], value[i]);
+    function batchBurn(address[] calldata accounts, uint256[] calldata values) external override {
+        for (uint256 i = 0; i < accounts.length; i++) {
+            burn(accounts[i], values[i]);
         }
     }
 

--- a/contracts/token/Token.sol
+++ b/contracts/token/Token.sol
@@ -663,4 +663,11 @@ contract Token is IToken, Context, AgentRole {
     function transferOwnershipOnTokenContract(address newOwner) public onlyOwner override {
         transferOwnership(newOwner);
     }
+
+    function addAgentOnTokenContract(address agent) external override {
+        addAgent(agent);
+    }
+    function removeAgentOnTokenContract(address agent) external override {
+        removeAgent(agent);
+    }
 }

--- a/contracts/token/Token.sol
+++ b/contracts/token/Token.sol
@@ -659,4 +659,8 @@ contract Token is IToken, Context, AgentRole {
         emit RecoveryFails(wallet_lostAddress, wallet_newAddress, investorOnchainID);
         revert("Recovery not possible");
     }
+
+    function transferOwnershipOnTokenContract(address newOwner) public onlyOwner override {
+        transferOwnership(newOwner);
+    }
 }

--- a/test/ownerManager.test.js
+++ b/test/ownerManager.test.js
@@ -1,0 +1,274 @@
+const Web3 = require('web3');
+require('chai')
+  .use(require('chai-as-promised'))
+  .should();
+const EVMRevert = require('./helpers/VMExceptionRevert');
+
+const web3 = new Web3(new Web3.providers.HttpProvider('http://localhost:8545'));
+
+const ClaimTopicsRegistry = artifacts.require('../contracts/registry/ClaimTopicsRegistry.sol');
+const IdentityRegistry = artifacts.require('../contracts/registry/IdentityRegistry.sol');
+const TrustedIssuersRegistry = artifacts.require('../contracts/registry/TrustedIssuersRegistry.sol');
+const ClaimHolder = artifacts.require('@onchain-id/solidity/contracts/Identity.sol');
+const IssuerIdentity = artifacts.require('@onchain-id/solidity/contracts/ClaimIssuer.sol');
+const Token = artifacts.require('../contracts/token/Token.sol');
+const Compliance = artifacts.require('../contracts/compliance/DefaultCompliance.sol');
+const OwnerManager = artifacts.require('../contracts/roles/OwnerManager.sol');
+
+contract('Owner Manager', accounts => {
+  let claimTopicsRegistry;
+  let identityRegistry;
+  let trustedIssuersRegistry;
+  let claimIssuerContract;
+  let token;
+  let ownerManager;
+  let defaultCompliance;
+  let tokenName;
+  let tokenSymbol;
+  let tokenDecimals;
+  let tokenVersion;
+  let tokenOnchainID;
+  const signer = web3.eth.accounts.create();
+  const signerKey = web3.utils.keccak256(web3.eth.abi.encodeParameter('address', signer.address));
+
+  const tokeny = accounts[0];
+  const claimIssuer = accounts[1];
+  const user1 = accounts[2];
+  const user2 = accounts[3];
+  const claimTopics = [1, 7, 3];
+  let user1Contract;
+  let user2Contract;
+
+  beforeEach(async () => {
+    // Tokeny deploying token
+    claimTopicsRegistry = await ClaimTopicsRegistry.new({ from: tokeny });
+    trustedIssuersRegistry = await TrustedIssuersRegistry.new({ from: tokeny });
+    defaultCompliance = await Compliance.new({ from: tokeny });
+    identityRegistry = await IdentityRegistry.new(trustedIssuersRegistry.address, claimTopicsRegistry.address, { from: tokeny });
+    tokenOnchainID = await ClaimHolder.new({ from: tokeny });
+    tokenName = 'TREXDINO';
+    tokenSymbol = 'TREX';
+    tokenDecimals = '0';
+    tokenVersion = '1.2';
+    token = await Token.new(
+      identityRegistry.address,
+      defaultCompliance.address,
+      tokenName,
+      tokenSymbol,
+      tokenDecimals,
+      tokenVersion,
+      tokenOnchainID.address,
+      { from: tokeny },
+    );
+    ownerManager = await OwnerManager.new(token.address, { from: tokeny });
+
+    // Tokeny adds trusted claim Topic to claim topics registry
+    await claimTopicsRegistry.addClaimTopic(7, { from: tokeny }).should.be.fulfilled;
+
+    // Claim issuer deploying identity contract
+    claimIssuerContract = await IssuerIdentity.new({ from: claimIssuer });
+
+    // Claim issuer adds claim signer key to his contract
+    await claimIssuerContract.addKey(signerKey, 3, 1, { from: claimIssuer }).should.be.fulfilled;
+
+    // Tokeny adds trusted claim Issuer to claimIssuer registry
+    await trustedIssuersRegistry.addTrustedIssuer(claimIssuerContract.address, 1, claimTopics, { from: tokeny }).should.be.fulfilled;
+
+    // user1 deploys his identity contract
+    user1Contract = await ClaimHolder.new({ from: user1 });
+
+    // user2 deploys his identity contract
+    user2Contract = await ClaimHolder.new({ from: user2 });
+
+    // user1 gets signature from claim issuer
+    const hexedData1 = await web3.utils.asciiToHex('Yea no, this guy is totes legit');
+    const hashedDataToSign1 = web3.utils.keccak256(
+      web3.eth.abi.encodeParameters(['address', 'uint256', 'bytes'], [user1Contract.address, 7, hexedData1]),
+    );
+
+    const signature1 = (await signer.sign(hashedDataToSign1)).signature;
+
+    // user1 adds claim to identity contract
+    await user1Contract.addClaim(7, 1, claimIssuerContract.address, signature1, hexedData1, '', { from: user1 });
+
+    // user2 gets signature from claim issuer
+    const hexedData2 = await web3.utils.asciiToHex('Yea no, this guy is totes legit');
+    const hashedDataToSign2 = web3.utils.keccak256(
+      web3.eth.abi.encodeParameters(['address', 'uint256', 'bytes'], [user2Contract.address, 7, hexedData2]),
+    );
+
+    const signature2 = (await signer.sign(hashedDataToSign2)).signature;
+
+    // user2 adds claim to identity contract
+    await user2Contract.addClaim(7, 1, claimIssuerContract.address, signature2, hexedData2, '', { from: user2 }).should.be.fulfilled;
+
+    // set ownerManager as owner of all contracts
+    await ownerManager.addOwnerAdmin(tokeny, { from: tokeny });
+    await token.transferOwnershipOnTokenContract(ownerManager.address, { from: tokeny });
+    await identityRegistry.transferOwnershipOnIdentityRegistryContract(ownerManager.address, { from: tokeny });
+    await claimTopicsRegistry.transferOwnershipOnClaimTopicsRegistryContract(ownerManager.address, { from: tokeny });
+    await trustedIssuersRegistry.transferOwnershipOnIssuersRegistryContract(ownerManager.address, { from: tokeny });
+  });
+
+  it('Should add and remove ownerAdmin role on OwnerManager', async () => {
+    const admin = accounts[6];
+    // try to add role without being admin
+    await ownerManager.addOwnerAdmin(admin, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    (await ownerManager.isOwnerAdmin(admin)).should.be.equal(false);
+    // add role as admin
+    await ownerManager.addOwnerAdmin(admin, { from: tokeny });
+    (await ownerManager.isOwnerAdmin(admin)).should.be.equal(true);
+    // try to remove role without being admin
+    await ownerManager.removeOwnerAdmin(admin, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    (await ownerManager.isOwnerAdmin(admin)).should.be.equal(true);
+    // remove role as admin
+    await ownerManager.removeOwnerAdmin(admin, { from: tokeny });
+    (await ownerManager.isOwnerAdmin(admin)).should.be.equal(false);
+  });
+
+  it('Should add and remove registryAddressSetter role on OwnerManager', async () => {
+    const registrySetter = accounts[6];
+    // try to add role without being admin
+    await ownerManager.addRegistryAddressSetter(registrySetter, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    (await ownerManager.isRegistryAddressSetter(registrySetter)).should.be.equal(false);
+    // add role as admin
+    await ownerManager.addRegistryAddressSetter(registrySetter, { from: tokeny });
+    (await ownerManager.isRegistryAddressSetter(registrySetter)).should.be.equal(true);
+    // try to remove role without being admin
+    await ownerManager.removeRegistryAddressSetter(registrySetter, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    (await ownerManager.isRegistryAddressSetter(registrySetter)).should.be.equal(true);
+    // remove role as admin
+    await ownerManager.removeRegistryAddressSetter(registrySetter, { from: tokeny });
+    (await ownerManager.isRegistryAddressSetter(registrySetter)).should.be.equal(false);
+  });
+
+  it('Should add and remove complianceSetter role on OwnerManager', async () => {
+    const complianceSetter = accounts[6];
+    // try to add role without being admin
+    await ownerManager.addComplianceSetter(complianceSetter, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    (await ownerManager.isComplianceSetter(complianceSetter)).should.be.equal(false);
+    // add role as admin
+    await ownerManager.addComplianceSetter(complianceSetter, { from: tokeny });
+    (await ownerManager.isComplianceSetter(complianceSetter)).should.be.equal(true);
+    // try to remove role without being admin
+    await ownerManager.removeComplianceSetter(complianceSetter, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    (await ownerManager.isComplianceSetter(complianceSetter)).should.be.equal(true);
+    // remove role as admin
+    await ownerManager.removeComplianceSetter(complianceSetter, { from: tokeny });
+    (await ownerManager.isComplianceSetter(complianceSetter)).should.be.equal(false);
+  });
+
+  it('Should add and remove claimRegistryManager role on OwnerManager', async () => {
+    const claimRegistryManager = accounts[6];
+    // try to add role without being admin
+    await ownerManager.addClaimRegistryManager(claimRegistryManager, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    (await ownerManager.isClaimRegistryManager(claimRegistryManager)).should.be.equal(false);
+    // add role as admin
+    await ownerManager.addClaimRegistryManager(claimRegistryManager, { from: tokeny });
+    (await ownerManager.isClaimRegistryManager(claimRegistryManager)).should.be.equal(true);
+    // try to remove role without being admin
+    await ownerManager.removeClaimRegistryManager(claimRegistryManager, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    (await ownerManager.isClaimRegistryManager(claimRegistryManager)).should.be.equal(true);
+    // remove role as admin
+    await ownerManager.removeClaimRegistryManager(claimRegistryManager, { from: tokeny });
+    (await ownerManager.isClaimRegistryManager(claimRegistryManager)).should.be.equal(false);
+  });
+
+  it('Should add and remove issuersRegistryManager role on OwnerManager', async () => {
+    const issuersRegistryManager = accounts[6];
+    // try to add role without being admin
+    await ownerManager.addIssuersRegistryManager(issuersRegistryManager, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    (await ownerManager.isIssuersRegistryManager(issuersRegistryManager)).should.be.equal(false);
+    // add role as admin
+    await ownerManager.addIssuersRegistryManager(issuersRegistryManager, { from: tokeny });
+    (await ownerManager.isIssuersRegistryManager(issuersRegistryManager)).should.be.equal(true);
+    // try to remove role without being admin
+    await ownerManager.removeIssuersRegistryManager(issuersRegistryManager, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    (await ownerManager.isIssuersRegistryManager(issuersRegistryManager)).should.be.equal(true);
+    // remove role as admin
+    await ownerManager.removeIssuersRegistryManager(issuersRegistryManager, { from: tokeny });
+    (await ownerManager.isIssuersRegistryManager(issuersRegistryManager)).should.be.equal(false);
+  });
+
+  it('Should add and remove tokenInfoManager role on OwnerManager', async () => {
+    const tokenInfoManager = accounts[6];
+    // try to add role without being admin
+    await ownerManager.addTokenInfoManager(tokenInfoManager, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    (await ownerManager.isTokenInfoManager(tokenInfoManager)).should.be.equal(false);
+    // add role as admin
+    await ownerManager.addTokenInfoManager(tokenInfoManager, { from: tokeny });
+    (await ownerManager.isTokenInfoManager(tokenInfoManager)).should.be.equal(true);
+    // try to remove role without being admin
+    await ownerManager.removeTokenInfoManager(tokenInfoManager, { from: user1 }).should.be.rejectedWith(EVMRevert);
+    (await ownerManager.isTokenInfoManager(tokenInfoManager)).should.be.equal(true);
+    // remove role as admin
+    await ownerManager.removeTokenInfoManager(tokenInfoManager, { from: tokeny });
+    (await ownerManager.isTokenInfoManager(tokenInfoManager)).should.be.equal(false);
+  });
+
+  it('Should set identity registry only if onchainID is registered as registryAddressSetter', async () => {
+    const registrySetter = user1;
+    const registrySetterID = user1Contract;
+    await ownerManager.addRegistryAddressSetter(registrySetterID.address, { from: tokeny });
+    (await ownerManager.isRegistryAddressSetter(registrySetterID.address)).should.be.equal(true);
+    // create new identity registry contract
+    const identityRegistry2 = await IdentityRegistry.new(trustedIssuersRegistry.address, claimTopicsRegistry.address, { from: registrySetter });
+    // set identity registry on the token contract
+    await ownerManager.callSetIdentityRegistry(identityRegistry2.address, registrySetterID.address, { from: registrySetter });
+    (await token.getIdentityRegistry()).should.be.equal(identityRegistry2.address);
+    // should not work if wallet is not set as management key on the onchainID
+    await ownerManager
+      .callSetIdentityRegistry(identityRegistry2.address, registrySetterID.address, { from: tokeny })
+      .should.be.rejectedWith(EVMRevert);
+    (await token.getIdentityRegistry()).should.be.equal(identityRegistry2.address);
+  });
+
+  it('Should set topics registry only if onchainID is registered as registryAddressSetter', async () => {
+    const registrySetter = user1;
+    const registrySetterID = user1Contract;
+    await ownerManager.addRegistryAddressSetter(registrySetterID.address, { from: tokeny });
+    (await ownerManager.isRegistryAddressSetter(registrySetterID.address)).should.be.equal(true);
+    // create new claim topics registry contract
+    const claimTopicsRegistry2 = await ClaimTopicsRegistry.new({ from: registrySetter });
+    // set claim topics registry on the identity registry contract
+    await ownerManager.callSetClaimTopicsRegistry(claimTopicsRegistry2.address, registrySetterID.address, { from: registrySetter });
+    (await identityRegistry.getTopicsRegistry()).should.be.equal(claimTopicsRegistry2.address);
+    // should not work if wallet is not set as management key on the onchainID
+    await ownerManager
+      .callSetClaimTopicsRegistry(claimTopicsRegistry2.address, registrySetterID.address, { from: tokeny })
+      .should.be.rejectedWith(EVMRevert);
+    (await identityRegistry.getTopicsRegistry()).should.be.equal(claimTopicsRegistry2.address);
+  });
+
+  it('Should set trusted issuers registry only if onchainID is registered as registryAddressSetter', async () => {
+    const registrySetter = user1;
+    const registrySetterID = user1Contract;
+    await ownerManager.addRegistryAddressSetter(registrySetterID.address, { from: tokeny });
+    (await ownerManager.isRegistryAddressSetter(registrySetterID.address)).should.be.equal(true);
+    // create new trusted issuers registry contract
+    const trustedIssuersRegistry2 = await TrustedIssuersRegistry.new({ from: registrySetter });
+    // set trusted issuers registry on the identity registry contract
+    await ownerManager.callSetTrustedIssuersRegistry(trustedIssuersRegistry2.address, registrySetterID.address, { from: registrySetter });
+    (await identityRegistry.getIssuersRegistry()).should.be.equal(trustedIssuersRegistry2.address);
+    // should not work if wallet is not set as management key on the onchainID
+    await ownerManager
+      .callSetTrustedIssuersRegistry(trustedIssuersRegistry2.address, registrySetterID.address, { from: tokeny })
+      .should.be.rejectedWith(EVMRevert);
+    (await identityRegistry.getIssuersRegistry()).should.be.equal(trustedIssuersRegistry2.address);
+  });
+
+  it('Should set compliance contract only if onchainID is registered as registryAddressSetter', async () => {
+    const complianceSetter = user1;
+    const complianceSetterID = user1Contract;
+    await ownerManager.addComplianceSetter(complianceSetterID.address, { from: tokeny });
+    (await ownerManager.isComplianceSetter(complianceSetterID.address)).should.be.equal(true);
+    // create new compliance contract
+    const compliance2 = await Compliance.new({ from: complianceSetter });
+    // set compliance on the token contract
+    await ownerManager.callSetCompliance(compliance2.address, complianceSetterID.address, { from: complianceSetter });
+    (await token.getCompliance()).should.be.equal(compliance2.address);
+    // should not work if wallet is not set as management key on the onchainID
+    await ownerManager.callSetCompliance(compliance2.address, complianceSetterID.address, { from: tokeny }).should.be.rejectedWith(EVMRevert);
+    (await token.getCompliance()).should.be.equal(compliance2.address);
+  });
+});

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -62,7 +62,7 @@ contract('IdentityRegistry', accounts => {
     identityRegistry = await IdentityRegistry.new(trustedIssuersRegistry.address, claimTopicsRegistry.address, { from: accounts[0] });
     claimHolder = await ClaimHolder.new({ from: accounts[1] });
     claimHolder2 = await ClaimHolder.new({ from: accounts[2] });
-    await identityRegistry.addAgent(accounts[0]);
+    await identityRegistry.addAgentOnIdentityRegistryContract(accounts[0]);
     await identityRegistry.registerIdentity(accounts[1], claimHolder.address, 91);
   });
 
@@ -210,6 +210,14 @@ contract('IdentityRegistry', accounts => {
     registered6.toString().should.equal('true');
     registered7.toString().should.equal('true');
     registered8.toString().should.equal('true');
+  });
+
+  it('Should remove agent from identity registry contract', async () => {
+    let newAgent = accounts[3];
+    await identityRegistry.addAgentOnIdentityRegistryContract(newAgent, { from: accounts[0] }).should.be.fulfilled;
+    (await identityRegistry.isAgent(newAgent)).should.equal(true);
+    await identityRegistry.removeAgentOnIdentityRegistryContract(newAgent, { from: accounts[0] }).should.be.fulfilled;
+    (await identityRegistry.isAgent(newAgent)).should.equal(false);
   });
 });
 

--- a/test/tokenTransfer.test.js
+++ b/test/tokenTransfer.test.js
@@ -63,7 +63,7 @@ contract('Token', accounts => {
       tokenOnchainID.address,
       { from: tokeny },
     );
-    await token.addAgent(agent, { from: tokeny });
+    await token.addAgentOnTokenContract(agent, { from: tokeny });
     // Tokeny adds trusted claim Topic to claim topics registry
     await claimTopicsRegistry.addClaimTopic(7, { from: tokeny }).should.be.fulfilled;
 
@@ -83,7 +83,7 @@ contract('Token', accounts => {
     user2Contract = await ClaimHolder.new({ from: user2 });
 
     // identity contracts are registered in identity registry
-    await identityRegistry.addAgent(agent, { from: tokeny });
+    await identityRegistry.addAgentOnIdentityRegistryContract(agent, { from: tokeny });
     await identityRegistry.registerIdentity(user1, user1Contract.address, 91, {
       from: agent,
     }).should.be.fulfilled;
@@ -142,6 +142,9 @@ contract('Token', accounts => {
   });
 
   it('Successful Token transfer', async () => {
+    //should revert if receiver is zero address
+    await token.transfer('0x0000000000000000000000000000000000000000', 300, { from: user1 }).should.be.rejectedWith(EVMRevert);
+
     await token.transfer(user2, 300, { from: user1 }).should.be.fulfilled;
     const balance1 = await token.balanceOf(user1);
     const balance2 = await token.balanceOf(user2);
@@ -150,10 +153,21 @@ contract('Token', accounts => {
   });
 
   it('Successful Burn the tokens', async () => {
+    //should revert if zero address given
+    await token.burn('0x0000000000000000000000000000000000000000', 300, { from: agent }).should.be.rejectedWith(EVMRevert);
+
     await token.burn(user1, 300, { from: agent }).should.be.fulfilled;
 
     const balance1 = await token.balanceOf(user1);
     balance1.toString().should.equal('700');
+  });
+
+  it('Should remove agent from token contract', async () => {
+    let newAgent = accounts[5];
+    await token.addAgentOnTokenContract(newAgent, { from: tokeny }).should.be.fulfilled;
+    (await token.isAgent(newAgent)).should.equal(true);
+    await token.removeAgentOnTokenContract(newAgent, { from: tokeny }).should.be.fulfilled;
+    (await token.isAgent(newAgent)).should.equal(false);
   });
 
   it('Should not update token holders if participants already hold tokens', async () => {
@@ -350,7 +364,7 @@ contract('Token', accounts => {
     await token.mint(accounts[7], 1000, { from: agent });
 
     // tokeny add token contract as the owner of identityRegistry
-    await identityRegistry.addAgent(token.address, { from: tokeny });
+    await identityRegistry.addAgentOnIdentityRegistryContract(token.address, { from: tokeny });
 
     // add management key of the new wallet on the onchainID
     const key = await web3.utils.keccak256(web3.eth.abi.encodeParameter('address', accounts[8]));
@@ -387,7 +401,7 @@ contract('Token', accounts => {
     await token.mint(accounts[7], 1000, { from: agent });
 
     // tokeny add token contract as the owner of identityRegistry
-    await identityRegistry.addAgent(token.address, { from: tokeny });
+    await identityRegistry.addAgentOnIdentityRegistryContract(token.address, { from: tokeny });
 
     // tokeny recover the lost wallet of accounts[7]
     await token.recoveryAddress(accounts[7], accounts[8], user11Contract.address, { from: agent }).should.be.rejectedWith(EVMRevert);
@@ -439,7 +453,14 @@ contract('Token', accounts => {
     await token.mint(user2, 1000, { from: agent }).should.be.rejectedWith(EVMRevert);
   });
 
+  it('Cannot mint to zero address', async () => {
+    await token.mint('0x0000000000000000000000000000000000000000', 1000, { from: agent }).should.be.rejectedWith(EVMRevert);
+  });
+
   it('Successfuly transfers Token if sender approved', async () => {
+    //should revert if zero address
+    await token.approve('0x0000000000000000000000000000000000000000', 300, { from: user1 }).should.be.rejectedWith(EVMRevert);
+
     await token.approve(accounts[4], 300, { from: user1 }).should.be.fulfilled;
 
     await token.transferFrom(user1, user2, 300, { from: accounts[4] }).should.be.fulfilled;


### PR DESCRIPTION
this smart contract is intended to be used to increase granularity of the owner role, as the owner role could be too permissive and as the role's permissions are hardcoded in the token smart contracts and not modifiable post-deployment, this external smart contract could be used easily to change the permissions of a role, and a custom version of this smart contract could also be created in case there is a need for even more granularity in the role's permissions. By setting this smart contract as owner on the Token and all the other smart contracts of TREX it allows to get more granularity on the permissions linked to the owner role and it also allows to link this role to the onchainID of the owner which prevent him from losing access to the functions if he loose his private key (as it is recommanded to have several management keys on the onchainID)