### PR TITLE
♻() unbind storage of identities from registry

### DIFF
--- a/contracts/compliance/LimitHolder.sol
+++ b/contracts/compliance/LimitHolder.sol
@@ -116,7 +116,7 @@ contract LimitHolder is ICompliance, AgentRole {
         if (holderIndices[addr] == 0) {
             shareholders.push(addr);
             holderIndices[addr] = shareholders.length;
-            uint16 country = identityRegistry.getInvestorCountryOfWallet(addr);
+            uint16 country = identityRegistry.investorCountry(addr);
             countryShareHolders[country]++;
         }
     }
@@ -140,7 +140,7 @@ contract LimitHolder is ICompliance, AgentRole {
         holderIndices[lastHolder] = holderIndices[addr];
         shareholders.pop();
         holderIndices[addr] = 0;
-        uint16 country = identityRegistry.getInvestorCountryOfWallet(addr);
+        uint16 country = identityRegistry.investorCountry(addr);
         countryShareHolders[country]--;
     }
 

--- a/contracts/registry/IIdentityRegistry.sol
+++ b/contracts/registry/IIdentityRegistry.sol
@@ -25,6 +25,7 @@ pragma solidity ^0.6.0;
 
 import "../registry/ITrustedIssuersRegistry.sol";
 import "../registry/IClaimTopicsRegistry.sol";
+import "../registry/IIdentityRegistryStorage.sol";
 
 import "@onchain-id/solidity/contracts/IClaimIssuer.sol";
 import "@onchain-id/solidity/contracts/IIdentity.sol";
@@ -34,14 +35,21 @@ interface IIdentityRegistry {
    /**
     *  this event is emitted when the ClaimTopicsRegistry has been set for the IdentityRegistry
     *  the event is emitted by the IdentityRegistry constructor
-    *  `_claimTopicsRegistry` is the address of the Claim Topics Registry contract
+    *  `claimTopicsRegistry` is the address of the Claim Topics Registry contract
     */
     event ClaimTopicsRegistrySet(address indexed claimTopicsRegistry);
 
    /**
+    *  this event is emitted when the IdentityRegistryStorage has been set for the IdentityRegistry
+    *  the event is emitted by the IdentityRegistry constructor
+    *  `identityStorage` is the address of the Identity Registry Storage contract
+    */
+    event IdentityStorageSet(address indexed identityStorage);
+
+   /**
     *  this event is emitted when the ClaimTopicsRegistry has been set for the IdentityRegistry
     *  the event is emitted by the IdentityRegistry constructor
-    *  `_claimTopicsRegistry` is the address of the Claim Topics Registry contract
+    *  `trustedIssuersRegistry` is the address of the Trusted Issuers Registry contract
     */
     event TrustedIssuersRegistrySet(address indexed trustedIssuersRegistry);
 
@@ -168,14 +176,18 @@ interface IIdentityRegistry {
     *  @dev Returns the onchainID of an investor.
     *  @param _userAddress The wallet of the investor
     */
-    function getIdentityOfWallet(address _userAddress) external view returns (IIdentity);
+    function identity(address _userAddress) external view returns (IIdentity);
 
    /**
     *  @dev Returns the country code of an investor.
     *  @param _userAddress The wallet of the investor
     */
-    function getInvestorCountryOfWallet(address _userAddress) external view returns (uint16);
+    function investorCountry(address _userAddress) external view returns (uint16);
 
+   /**
+    *  @dev Returns the TrustedIssuersRegistry linked to the current IdentityRegistry.
+    */
+    function identityStorage() external view returns (IIdentityRegistryStorage);
 
    /**
     *  @dev Returns the TrustedIssuersRegistry linked to the current IdentityRegistry.

--- a/contracts/registry/IIdentityRegistryStorage.sol
+++ b/contracts/registry/IIdentityRegistryStorage.sol
@@ -1,0 +1,133 @@
+pragma solidity ^0.6.0;
+
+import "@onchain-id/solidity/contracts/IIdentity.sol";
+
+interface IIdentityRegistryStorage {
+
+   /**
+    *  this event is emitted when an Identity is registered into the storage contract.
+    *  the event is emitted by the 'registerIdentity' function
+    *  `investorAddress` is the address of the investor's wallet
+    *  `identity` is the address of the Identity smart contract (onchainID)
+    */
+    event IdentityStored(address indexed investorAddress, IIdentity indexed identity);
+
+   /**
+    *  this event is emitted when an Identity is removed from the storage contract.
+    *  the event is emitted by the 'deleteIdentity' function
+    *  `investorAddress` is the address of the investor's wallet
+    *  `identity` is the address of the Identity smart contract (onchainID)
+    */
+    event IdentityUnStored(address indexed investorAddress, IIdentity indexed identity);
+
+   /**
+    *  this event is emitted when an Identity has been updated
+    *  the event is emitted by the 'updateIdentity' function
+    *  `oldIdentity` is the old Identity contract's address to update
+    *  `newIdentity` is the new Identity contract's
+    */
+    event IdentityModified(IIdentity indexed oldIdentity, IIdentity indexed newIdentity);
+
+   /**
+    *  this event is emitted when an Identity's country has been updated
+    *  the event is emitted by the 'updateCountry' function
+    *  `investorAddress` is the address on which the country has been updated
+    *  `country` is the numeric code (ISO 3166-1) of the new country
+    */
+    event CountryModified(address indexed investorAddress, uint16 indexed country);
+
+   /**
+    *  this event is emitted when an Identity Registry is bound to the storage contract
+    *  the event is emitted by the 'addIdentityRegistry' function
+    *  `identityRegistry` is the address of the identity registry added
+    */
+    event IdentityRegistryBound(address indexed identityRegistry);
+
+   /**
+    *  this event is emitted when an Identity Registry is unbound from the storage contract
+    *  the event is emitted by the 'removeIdentityRegistry' function
+    *  `identityRegistry` is the address of the identity registry removed
+    */
+    event IdentityRegistryUnbound(address indexed identityRegistry);
+
+   /**
+    *  @dev Returns the identity registries linked to the storage contract
+    */
+    function linkedIdentityRegistries() external view returns (address[] memory);
+
+   /**
+    *  @dev Returns the onchainID of an investor.
+    *  @param _userAddress The wallet of the investor
+    */
+    function storedIdentity(address _userAddress) external view returns (IIdentity);
+
+   /**
+    *  @dev Returns the country code of an investor.
+    *  @param _userAddress The wallet of the investor
+    */
+    function storedInvestorCountry(address _userAddress) external view returns (uint16);
+
+   /**
+    *  @dev adds an identity contract corresponding to a user address in the storage.
+    *  Requires that the user doesn't have an identity contract already registered.
+    *  This function can only be called by an address set as agent of the smart contract
+    *  @param _userAddress The address of the user
+    *  @param _identity The address of the user's identity contract
+    *  @param _country The country of the investor
+    *  emits `IdentityStored` event
+    */
+    function addIdentityToStorage(address _userAddress, IIdentity _identity, uint16 _country) external;
+
+   /**
+    *  @dev Removes an user from the storage.
+    *  Requires that the user have an identity contract already deployed that will be deleted.
+    *  This function can only be called by an address set as agent of the smart contract
+    *  @param _userAddress The address of the user to be removed
+    *  emits `IdentityUnStored` event
+    */
+    function removeIdentityFromStorage(address _userAddress) external;
+
+   /**
+    *  @dev Updates the country corresponding to a user address.
+    *  Requires that the user should have an identity contract already deployed that will be replaced.
+    *  This function can only be called by an address set as agent of the smart contract
+    *  @param _userAddress The address of the user
+    *  @param _country The new country of the user
+    *  emits `CountryModified` event
+    */
+    function modifyStoredInvestorCountry(address _userAddress, uint16 _country) external;
+
+   /**
+    *  @dev Updates an identity contract corresponding to a user address.
+    *  Requires that the user address should be the owner of the identity contract.
+    *  Requires that the user should have an identity contract already deployed that will be replaced.
+    *  This function can only be called by an address set as agent of the smart contract
+    *  @param _userAddress The address of the user
+    *  @param _identity The address of the user's new identity contract
+    *  emits `IdentityModified` event
+    */
+    function modifyStoredIdentity(address _userAddress, IIdentity _identity) external;
+
+   /**
+    *  @notice Transfers the Ownership of the Identity Registry Storage to a new Owner.
+    *  This function can only be called by the wallet set as owner of the smart contract
+    *  @param _newOwner The new owner of this contract.
+    */
+    function transferOwnershipOnIdentityRegistryStorage(address _newOwner) external;
+
+   /**
+    *  @notice Adds an identity registry as agent of the Identity Registry Storage Contract.
+    *  This function can only be called by the wallet set as owner of the smart contract
+    *  This function adds the identity registry to the list of identityRegistries linked to the storage contract
+    *  @param _identityRegistry The identity registry address to add.
+    */
+    function bindIdentityRegistry(address _identityRegistry) external;
+
+   /**
+    *  @notice Removes an identity registry from being agent of the Identity Registry Storage Contract.
+    *  This function can only be called by the wallet set as owner of the smart contract
+    *  This function removes the identity registry from the list of identityRegistries linked to the storage contract
+    *  @param _identityRegistry The identity registry address to remove.
+    */
+    function unbindIdentityRegistry(address _identityRegistry) external;
+}

--- a/contracts/registry/IdentityRegistryStorage.sol
+++ b/contracts/registry/IdentityRegistryStorage.sol
@@ -1,0 +1,113 @@
+pragma solidity ^0.6.0;
+
+import "@onchain-id/solidity/contracts/IIdentity.sol";
+import "../roles/AgentRole.sol";
+import "../registry/IIdentityRegistryStorage.sol";
+
+
+contract IdentityRegistryStorage is IIdentityRegistryStorage, AgentRole{
+
+    /// mapping between a user address and the corresponding identity contract
+    mapping(address => IIdentity) private identity;
+
+    /// mapping between a user address and its corresponding country
+    mapping(address => uint16) private investorCountry;
+
+    /// array of Identity Registries linked to this storage
+    address[] private identityRegistries;
+
+   /**
+    *  @dev See {IIdentityRegistryStorage-linkedIdentityRegistries}.
+    */
+    function linkedIdentityRegistries() public override view returns (address[] memory){
+        return identityRegistries;
+    }
+
+   /**
+    *  @dev See {IIdentityRegistryStorage-storedIdentity}.
+    */
+    function storedIdentity(address _userAddress) public override view returns (IIdentity){
+        return identity[_userAddress];
+    }
+
+   /**
+    *  @dev See {IIdentityRegistryStorage-storedInvestorCountry}.
+    */
+    function storedInvestorCountry(address _userAddress) public override view returns (uint16){
+        return investorCountry[_userAddress];
+    }
+
+   /**
+    *  @dev See {IIdentityRegistryStorage-addIdentityToStorage}.
+    */
+    function addIdentityToStorage(address _userAddress, IIdentity _identity, uint16 _country) public override onlyAgent {
+        require(address(_identity) != address(0), "contract address can't be a zero address");
+        require(address(identity[_userAddress]) == address(0), "identity contract already exists, please use update");
+        identity[_userAddress] = _identity;
+        investorCountry[_userAddress] = _country;
+        emit IdentityStored(_userAddress, _identity);
+    }
+
+   /**
+    *  @dev See {IIdentityRegistryStorage-modifyStoredIdentity}.
+    */
+    function modifyStoredIdentity(address _userAddress, IIdentity _identity) public override onlyAgent {
+        require(address(identity[_userAddress]) != address(0));
+        require(address(_identity) != address(0), "contract address can't be a zero address");
+        identity[_userAddress] = _identity;
+        emit IdentityModified(identity[_userAddress], _identity);
+    }
+
+   /**
+    *  @dev See {IIdentityRegistryStorage-modifyStoredInvestorCountry}.
+    */
+    function modifyStoredInvestorCountry(address _userAddress, uint16 _country) public override onlyAgent {
+        require(address(identity[_userAddress]) != address(0));
+        investorCountry[_userAddress] = _country;
+        emit CountryModified(_userAddress, _country);
+    }
+
+   /**
+    *  @dev See {IIdentityRegistryStorage-removeIdentityFromStorage}.
+    */
+    function removeIdentityFromStorage(address _userAddress) public override onlyAgent {
+        require(address(identity[_userAddress]) != address(0), "you haven't registered an identity yet");
+        delete identity[_userAddress];
+        emit IdentityUnStored(_userAddress, identity[_userAddress]);
+    }
+
+   /**
+    *  @dev See {IIdentityRegistryStorage-transferOwnershipOnIdentityRegistryStorage}.
+    */
+    function transferOwnershipOnIdentityRegistryStorage(address _newOwner) external override onlyOwner {
+        transferOwnership(_newOwner);
+    }
+
+    /**
+    *  @dev See {IIdentityRegistryStorage-bindIdentityRegistry}.
+    */
+    function bindIdentityRegistry(address _identityRegistry) external override {
+        addAgent(_identityRegistry);
+        identityRegistries.push(_identityRegistry);
+        emit IdentityRegistryBound(_identityRegistry);
+    }
+
+    /**
+     *  @dev See {IIdentityRegistryStorage-unbindIdentityRegistry}.
+     */
+    function unbindIdentityRegistry(address _identityRegistry) external override {
+        require(identityRegistries.length > 0, "identity registry is not stored");
+        uint length = identityRegistries.length;
+        for (uint i = 0; i < length; i++) {
+            if (identityRegistries[i] == _identityRegistry) {
+                delete identityRegistries[i];
+                identityRegistries[i] = identityRegistries[length - 1];
+                delete identityRegistries[length - 1];
+                identityRegistries.pop();
+                break;
+            }
+        }
+        removeAgent(_identityRegistry);
+        emit IdentityRegistryUnbound(_identityRegistry);
+    }
+}

--- a/contracts/token/Token.sol
+++ b/contracts/token/Token.sol
@@ -524,7 +524,7 @@ contract Token is IToken, Context, AgentRole {
         if (_onchainID.keyHasPurpose(_key, 1)) {
             uint investorTokens = balanceOf(_lostWallet);
             uint _frozenTokens = frozenTokens[_lostWallet];
-            tokenIdentityRegistry.registerIdentity(_newWallet, _onchainID, tokenIdentityRegistry.getInvestorCountryOfWallet(_lostWallet));
+            tokenIdentityRegistry.registerIdentity(_newWallet, _onchainID, tokenIdentityRegistry.investorCountry(_lostWallet));
             tokenIdentityRegistry.deleteIdentity(_lostWallet);
             forcedTransfer(_lostWallet, _newWallet, investorTokens);
             if (_frozenTokens > 0) {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@onchain-id/solidity": "1.0.0-beta3",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
+    "node-fetch": "^2.6.0",
     "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^13.0.0",
     "eslint-config-prettier": "^3.3.0",

--- a/test/compliance.test.js
+++ b/test/compliance.test.js
@@ -13,10 +13,12 @@ const IssuerIdentity = artifacts.require('@onchain-id/solidity/contracts/ClaimIs
 const Token = artifacts.require('../contracts/token/Token.sol');
 const Compliance = artifacts.require('../contracts/compliance/DefaultCompliance.sol');
 const LimitCompliance = artifacts.require('../contracts/compliance/LimitHolder.sol');
+const IdentityRegistryStorage = artifacts.require('../contracts/registry/IdentityRegistryStorage.sol');
 
 contract('Compliance', accounts => {
   let claimTopicsRegistry;
   let identityRegistry;
+  let identityRegistryStorage;
   let trustedIssuersRegistry;
   let claimIssuerContract;
   let token;
@@ -43,7 +45,10 @@ contract('Compliance', accounts => {
     claimTopicsRegistry = await ClaimTopicsRegistry.new({ from: tokeny });
     trustedIssuersRegistry = await TrustedIssuersRegistry.new({ from: tokeny });
     defaultCompliance = await Compliance.new({ from: tokeny });
-    identityRegistry = await IdentityRegistry.new(trustedIssuersRegistry.address, claimTopicsRegistry.address, { from: tokeny });
+    identityRegistryStorage = await IdentityRegistryStorage.new({ from: tokeny });
+    identityRegistry = await IdentityRegistry.new(trustedIssuersRegistry.address, claimTopicsRegistry.address, identityRegistryStorage.address, {
+      from: tokeny,
+    });
     tokenOnchainID = await ClaimHolder.new({ from: tokeny });
     tokenName = 'TREXDINO';
     tokenSymbol = 'TREX';
@@ -60,6 +65,7 @@ contract('Compliance', accounts => {
       { from: tokeny },
     );
     limitCompliance = await LimitCompliance.new(token.address, 2, { from: tokeny });
+    await identityRegistryStorage.bindIdentityRegistry(identityRegistry.address, { from: tokeny });
     await token.addAgent(agent, { from: tokeny });
     // Tokeny adds trusted claim Topic to claim topics registry
     await claimTopicsRegistry.addClaimTopic(7, { from: tokeny }).should.be.fulfilled;

--- a/test/ownerManager.test.js
+++ b/test/ownerManager.test.js
@@ -225,7 +225,6 @@ contract('Owner Manager', accounts => {
       identityRegistryStorage.address,
       { from: registrySetter },
     );
-    await identityRegistryStorage.bindIdentityRegistry(identityRegistry2.address, { from: tokeny });
     // set identity registry on the token contract
     await ownerManager.callSetIdentityRegistry(identityRegistry2.address, registrySetterID.address, { from: registrySetter });
     (await token.identityRegistry()).should.be.equal(identityRegistry2.address);

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -75,6 +75,15 @@ contract('IdentityRegistry', accounts => {
     (await identityRegistry.identityStorage()).toString().should.equal(identityRegistryStorage.address);
   });
 
+  it('unbind identity registry should revert if there is no identity registry bound', async () => {
+    // unbind identity contract
+    await identityRegistryStorage.unbindIdentityRegistry(identityRegistry.address, { from: accounts[0] }).should.be.fulfilled;
+    // adds the identity registry contract as agent without binding
+    await identityRegistryStorage.addAgent(identityRegistry.address, { from: accounts[0] }).should.be.fulfilled;
+    // unbind should fail as identity registry is agent but not bound
+    await identityRegistryStorage.unbindIdentityRegistry(identityRegistry.address, { from: accounts[0] }).should.be.rejectedWith(EVMRevert);
+  });
+
   it('should bind and unbind identity registry from storage', async () => {
     const identityRegistry1 = await IdentityRegistry.new(
       trustedIssuersRegistry.address,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4142,6 +4142,11 @@ node-emoji@^1.10.0:
   dependencies:
     lodash.toarray "^4.4.0"
 
+node-fetch@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+
 nopt@3.x:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"


### PR DESCRIPTION
the goal of this PR is to allow several identity registries to share the same list of registered identities while remaining independent in terms of investor eligibility criteria (coming from trusted issuers registry and claim topics registry that are specific to each identity registry).