### PR TITLE
➕() Import ownable and role as they were removed from OZ

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,18 +586,18 @@ The project is created with truffle. Hence all truffle commands will work.
 
 ### Setup
 
-Install dependencies `npm install`.
+Install dependencies `yarn`.
 
   </div>
   <div id='runTest'>
 
 ### Run tests
 
-`npm run test`
+`yarn test`
 
 In case the command breaks, it may be due to node versioning issues. 
 
-Run `npm rebuild` and then run `npm run test` again.
+Run `yarn build` and then run `npm test` again.
 
   </div>
 </div>

--- a/contracts/compliance/DefaultCompliance.sol
+++ b/contracts/compliance/DefaultCompliance.sol
@@ -24,7 +24,8 @@
 pragma solidity ^0.6.0;
 
 import "./ICompliance.sol";
-import "openzeppelin-solidity/contracts/access/Ownable.sol";
+
+import "../Roles/Ownable.sol";
 
 contract DefaultCompliance is ICompliance, Ownable {
 

--- a/contracts/compliance/DefaultCompliance.sol
+++ b/contracts/compliance/DefaultCompliance.sol
@@ -25,7 +25,7 @@ pragma solidity ^0.6.0;
 
 import "./ICompliance.sol";
 
-import "../Roles/Ownable.sol";
+import "../roles/Ownable.sol";
 
 contract DefaultCompliance is ICompliance, Ownable {
 
@@ -64,4 +64,3 @@ contract DefaultCompliance is ICompliance, Ownable {
         transferOwnership(newOwner);
     }
 }
-

--- a/contracts/compliance/DefaultCompliance.sol
+++ b/contracts/compliance/DefaultCompliance.sol
@@ -24,7 +24,7 @@
 pragma solidity ^0.6.0;
 
 import "./ICompliance.sol";
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "openzeppelin-solidity/contracts/access/Ownable.sol";
 
 contract DefaultCompliance is ICompliance, Ownable {
 

--- a/contracts/registry/ClaimTopicsRegistry.sol
+++ b/contracts/registry/ClaimTopicsRegistry.sol
@@ -24,7 +24,7 @@
 pragma solidity ^0.6.0;
 
 import "../registry/IClaimTopicsRegistry.sol";
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "openzeppelin-solidity/contracts/access/Ownable.sol";
 
 contract ClaimTopicsRegistry is IClaimTopicsRegistry, Ownable {
 

--- a/contracts/registry/ClaimTopicsRegistry.sol
+++ b/contracts/registry/ClaimTopicsRegistry.sol
@@ -24,7 +24,7 @@
 pragma solidity ^0.6.0;
 
 import "../registry/IClaimTopicsRegistry.sol";
-import "openzeppelin-solidity/contracts/access/Ownable.sol";
+import "../roles/Ownable.sol";
 
 contract ClaimTopicsRegistry is IClaimTopicsRegistry, Ownable {
 

--- a/contracts/registry/IdentityRegistry.sol
+++ b/contracts/registry/IdentityRegistry.sol
@@ -30,8 +30,7 @@ import "../registry/IClaimTopicsRegistry.sol";
 import "../registry/ITrustedIssuersRegistry.sol";
 import "../registry/IIdentityRegistry.sol";
 import "../roles/AgentRole.sol";
-
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "../roles/Ownable.sol";
 
 contract IdentityRegistry is IIdentityRegistry, AgentRole {
     /// mapping between a user address and its corresponding identity contract

--- a/contracts/registry/TrustedIssuersRegistry.sol
+++ b/contracts/registry/TrustedIssuersRegistry.sol
@@ -23,10 +23,10 @@
 
 pragma solidity ^0.6.0;
 
+import "@onchain-id/solidity/contracts/IClaimIssuer.sol";
 
 import "../registry/ITrustedIssuersRegistry.sol";
-import "@onchain-id/solidity/contracts/IClaimIssuer.sol";
-import "openzeppelin-solidity/contracts/access/Ownable.sol";
+import "../roles/Ownable.sol";
 
 contract TrustedIssuersRegistry is ITrustedIssuersRegistry, Ownable {
 

--- a/contracts/registry/TrustedIssuersRegistry.sol
+++ b/contracts/registry/TrustedIssuersRegistry.sol
@@ -26,7 +26,7 @@ pragma solidity ^0.6.0;
 
 import "../registry/ITrustedIssuersRegistry.sol";
 import "@onchain-id/solidity/contracts/IClaimIssuer.sol";
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "openzeppelin-solidity/contracts/access/Ownable.sol";
 
 contract TrustedIssuersRegistry is ITrustedIssuersRegistry, Ownable {
 

--- a/contracts/roles/AgentRole.sol
+++ b/contracts/roles/AgentRole.sol
@@ -23,8 +23,8 @@
 
 pragma solidity ^0.6.0;
 
-import "openzeppelin-solidity/contracts/access/Roles.sol";
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "./Roles.sol";
+import "./Ownable.sol";
 
 contract AgentRole is Ownable {
     using Roles for Roles.Role;

--- a/contracts/roles/AgentRoles.sol
+++ b/contracts/roles/AgentRoles.sol
@@ -23,8 +23,8 @@
 
 pragma solidity ^0.6.0;
 
-import "openzeppelin-solidity/contracts/access/Roles.sol";
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "./Roles.sol";
+import "./Ownable.sol";
 
 contract AgentRoles is Ownable {
     using Roles for Roles.Role;

--- a/contracts/roles/Ownable.sol
+++ b/contracts/roles/Ownable.sol
@@ -1,0 +1,78 @@
+pragma solidity ^0.6.0;
+
+import "openzeppelin-solidity/contracts/GSN/Context.sol";
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+contract Ownable is Context {
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    constructor () internal {
+        address msgSender = _msgSender();
+        _owner = msgSender;
+        emit OwnershipTransferred(address(0), msgSender);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(isOwner(), "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Returns true if the caller is the current owner.
+     */
+    function isOwner() public view returns (bool) {
+        return _msgSender() == _owner;
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions anymore. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby removing any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public virtual onlyOwner {
+        emit OwnershipTransferred(_owner, address(0));
+        _owner = address(0);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual onlyOwner {
+        _transferOwnership(newOwner);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     */
+    function _transferOwnership(address newOwner) internal virtual {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+}

--- a/contracts/roles/OwnerRoles.sol
+++ b/contracts/roles/OwnerRoles.sol
@@ -23,8 +23,8 @@
 
 pragma solidity ^0.6.0;
 
-import "openzeppelin-solidity/contracts/access/Roles.sol";
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "./Roles.sol";
+import "./Ownable.sol";
 
 contract OwnerRoles is Ownable {
     using Roles for Roles.Role;

--- a/contracts/roles/Roles.sol
+++ b/contracts/roles/Roles.sol
@@ -1,0 +1,36 @@
+pragma solidity ^0.6.0;
+
+/**
+ * @title Roles
+ * @dev Library for managing addresses assigned to a Role.
+ */
+library Roles {
+    struct Role {
+        mapping (address => bool) bearer;
+    }
+
+    /**
+     * @dev Give an account access to this role.
+     */
+    function add(Role storage role, address account) internal {
+        require(!has(role, account), "Roles: account already has role");
+        role.bearer[account] = true;
+    }
+
+    /**
+     * @dev Remove an account's access to this role.
+     */
+    function remove(Role storage role, address account) internal {
+        require(has(role, account), "Roles: account does not have role");
+        role.bearer[account] = false;
+    }
+
+    /**
+     * @dev Check if an account has this role.
+     * @return bool
+     */
+    function has(Role storage role, address account) internal view returns (bool) {
+        require(account != address(0), "Roles: account is the zero address");
+        return role.bearer[account];
+    }
+}

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ganache-cli": "^6.9.1",
     "husky": "^4.2.3",
     "lint-staged": "^10.0.7",
-    "openzeppelin-solidity": "^3.0.0-beta.0",
+    "openzeppelin-solidity": "^3.0.0-rc.0",
     "prettier": "^1.19.1",
     "solhint": "^2.3.0",
     "solidity-coverage": "^0.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4286,10 +4286,10 @@ opencollective-postinstall@^2.0.2:
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz#5657f1bede69b6e33a45939b061eb53d3c6c3a89"
   integrity sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==
 
-openzeppelin-solidity@^3.0.0-beta.0:
-  version "3.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/openzeppelin-solidity/-/openzeppelin-solidity-3.0.0-beta.0.tgz#9be6d4ffc1975a13e01594c1ad9bcc70eec58e65"
-  integrity sha512-lwCPDIj2CMBcUGOHAMtJbWn2Rb1R6pJJeH/Gzari/VEt5XwgU/fWVo9TRjWyE9KBhH+36mlSKpCaskzvn+KMZw==
+openzeppelin-solidity@^3.0.0-rc.0:
+  version "3.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/openzeppelin-solidity/-/openzeppelin-solidity-3.0.0-rc.0.tgz#8e8328749ad5f4e8e65a8364e5e12b956e0a22f1"
+  integrity sha512-cftpu1YvJgYbYcUVlTAOi+JvMF+hkvwdjLtA3ZLiBjVfEsf5HQGKL293dr/F31PRZSGurH+31Y0RxOPUvExGQQ==
 
 optimist@^0.6.1:
   version "0.6.1"


### PR DESCRIPTION
OppenZeppelin overrided their 3.0.0-beta.0 version and removed the Roles.sol and moved the Ownable.sol.

The implementation of Roles is no longer compatible. I imported the old version in our codebase, as well as the old Ownable.