### PR TITLE
Proposal/refactoring token contract

### DIFF
--- a/contracts/roles/OwnerManager.sol
+++ b/contracts/roles/OwnerManager.sol
@@ -73,32 +73,6 @@ contract OwnerManager is OwnerRoles {
     }
 
    /**
-    *  @dev calls the `setName` function on the token contract
-    *  OwnerManager has to be set as owner on the token smart contract to process this function
-    *  See {IToken-setName}.
-    *  Requires that `_onchainID` is set as TokenInfoManager on the OwnerManager contract
-    *  Requires that msg.sender is a MANAGEMENT KEY on `_onchainID`
-    *  @param _onchainID the _onchainID contract of the caller, e.g. "i call this function and i am Bob"
-    */
-    function callSetTokenName(string calldata _name, IIdentity _onchainID) external {
-        require(isTokenInfoManager(address(_onchainID)) && _onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Token Information Manager");
-        token.setName(_name);
-    }
-
-   /**
-    *  @dev calls the `setSymbol` function on the token contract
-    *  OwnerManager has to be set as owner on the token smart contract to process this function
-    *  See {IToken-setSymbol}.
-    *  Requires that `_onchainID` is set as TokenInfoManager on the OwnerManager contract
-    *  Requires that msg.sender is a MANAGEMENT KEY on `_onchainID`
-    *  @param _onchainID the _onchainID contract of the caller, e.g. "i call this function and i am Bob"
-    */
-    function callSetTokenSymbol(string calldata _symbol, IIdentity _onchainID) external {
-        require(isTokenInfoManager(address(_onchainID)) && _onchainID.keyHasPurpose(keccak256(abi.encode(msg.sender)), 1), "Role: Sender is NOT Token Information Manager");
-        token.setSymbol(_symbol);
-    }
-
-   /**
     *  @dev calls the `setOnchainID` function on the token contract
     *  OwnerManager has to be set as owner on the token smart contract to process this function
     *  See {IToken-setOnchainID}.

--- a/contracts/token/IToken.sol
+++ b/contracts/token/IToken.sol
@@ -176,22 +176,6 @@ interface IToken is IERC20 {
     function getFrozenTokens(address _userAddress) external view returns (uint256);
 
    /**
-    *  @dev sets the token name
-    *  @param _name the name of token to set
-    *  Only the owner of the token smart contract can call this function
-    *  emits a `UpdatedTokenInformation` event
-    */
-    function setName(string calldata _name) external;
-
-   /**
-    *  @dev sets the token symbol
-    *  @param _symbol the token symbol to set
-    *  Only the owner of the token smart contract can call this function
-    *  emits a `UpdatedTokenInformation` event
-    */
-    function setSymbol(string calldata _symbol) external;
-
-   /**
     *  @dev sets the onchain ID of the token
     *  @param _onchainID the address of the onchain ID to set
     *  Only the owner of the token smart contract can call this function

--- a/contracts/token/Token.sol
+++ b/contracts/token/Token.sol
@@ -82,6 +82,9 @@ contract Token is IToken, AgentRole {
         address _onchainID
         )
     public {
+        require(bytes(_name).length != 0, "Name should be defined");
+        require(bytes(_symbol).length != 0, "Symbol should be defined");
+
         tokenName = _name;
         tokenSymbol = _symbol;
         tokenDecimals = _decimals;
@@ -240,22 +243,6 @@ contract Token is IToken, AgentRole {
     */
     function version() public override view returns (string memory){
         return TOKEN_VERSION;
-    }
-
-   /**
-    *  @dev See {IToken-setName}.
-    */
-    function setName(string calldata _name) external override onlyOwner {
-        tokenName = _name;
-        emit UpdatedTokenInformation(tokenName, tokenSymbol, tokenDecimals, TOKEN_VERSION, tokenOnchainID);
-    }
-
-   /**
-    *  @dev See {IToken-setSymbol}.
-    */
-    function setSymbol(string calldata _symbol) external override onlyOwner {
-        tokenSymbol = _symbol;
-        emit UpdatedTokenInformation(tokenName, tokenSymbol, tokenDecimals, TOKEN_VERSION, tokenOnchainID);
     }
 
    /**

--- a/test/ownerManager.test.js
+++ b/test/ownerManager.test.js
@@ -337,20 +337,6 @@ contract('Owner Manager', accounts => {
     (await trustedIssuersRegistry.hasClaimTopic(claimIssuerContract.address, 4)).should.be.equal(true);
   });
 
-  it('Should set token name only if onchainID is registered as TokenInfoManager', async () => {
-    const tokenInfoManager = accounts[6];
-    const tokenInfoManagerIdentity = await ClaimHolder.new({ from: tokenInfoManager });
-    // should revert if sender is not token info manager
-    await ownerManager.callSetTokenName('TREXDINO1', tokenInfoManagerIdentity.address, { from: tokenInfoManager }).should.be.rejectedWith(EVMRevert);
-
-    // should set information if sender is token info manager
-    await ownerManager.addTokenInfoManager(tokenInfoManagerIdentity.address, { from: tokeny }).should.be.fulfilled;
-    (await ownerManager.isTokenInfoManager(tokenInfoManagerIdentity.address)).should.be.equal(true);
-    await ownerManager.callSetTokenName('TREXDINO1', tokenInfoManagerIdentity.address, { from: tokenInfoManager }).should.be.fulfilled;
-
-    (await token.name()).should.equal('TREXDINO1');
-  });
-
   it('Should set token onchain ID only if sender onchainID is registered as TokenInfoManager', async () => {
     const tokenInfoManager = accounts[6];
     const tokenInfoManagerIdentity = await ClaimHolder.new({ from: tokenInfoManager });
@@ -368,21 +354,6 @@ contract('Owner Manager', accounts => {
     }).should.be.fulfilled;
 
     (await token.onchainID()).should.equal('0x0000000000000000000000000000000000000000');
-  });
-
-  it('Should set token symbol only if onchainID is registered as TokenInfoManager', async () => {
-    const tokenInfoManager = accounts[6];
-    const tokenInfoManagerIdentity = await ClaimHolder.new({ from: tokenInfoManager });
-    // should revert if sender is not token info manager
-    await ownerManager.callSetTokenSymbol('TREX1', tokenInfoManagerIdentity.address, { from: tokenInfoManager }).should.be.rejectedWith(EVMRevert);
-
-    // should set information if sender is token info manager
-    await ownerManager.addTokenInfoManager(tokenInfoManagerIdentity.address, { from: tokeny }).should.be.fulfilled;
-    (await ownerManager.isTokenInfoManager(tokenInfoManagerIdentity.address)).should.be.equal(true);
-
-    await ownerManager.callSetTokenSymbol('TREX1', tokenInfoManagerIdentity.address, { from: tokenInfoManager }).should.be.fulfilled;
-
-    (await token.symbol()).should.equal('TREX1');
   });
 
   it('Should add claim topic in the claim topics registry only if onchainID is registered as ClaimRegistryManager', async () => {

--- a/test/tokenTransfer.test.js
+++ b/test/tokenTransfer.test.js
@@ -118,6 +118,20 @@ contract('Token', accounts => {
     await token.mint(user1, 1000, { from: agent });
   });
 
+  it('constructor reverts if Name is empty', async () => {
+    await Token.new(identityRegistry.address, defaultCompliance.address, '', tokenSymbol, tokenDecimals, tokenOnchainID.address, {
+      from: tokeny,
+    }).should.be.rejectedWith('VM Exception while processing transaction: revert Name should be defined -- Reason given: Name should be defined.');
+  });
+
+  it('constructor reverts if Symbol is empty', async () => {
+    await Token.new(identityRegistry.address, defaultCompliance.address, tokenName, '', tokenDecimals, tokenOnchainID.address, {
+      from: tokeny,
+    }).should.be.rejectedWith(
+      'VM Exception while processing transaction: revert Symbol should be defined -- Reason given: Symbol should be defined.',
+    );
+  });
+
   it('decimals returns the number of decimals of the token', async () => {
     const decimals1 = await token.decimals().should.be.fulfilled;
     decimals1.toString().should.equal('0');
@@ -658,20 +672,6 @@ contract('Token', accounts => {
     const balance2 = await token.balanceOf(user2);
     balance1.toString().should.equal('800');
     balance2.toString().should.equal('200');
-  });
-
-  it('Updates the token name', async () => {
-    const tx = await token.setName('TREXDINO42');
-    log(`[${calculateETH(tx.receipt.gasUsed)} ETH] --> fees of setName transaction`);
-    const newTokenName = await token.name();
-    newTokenName.should.equal('TREXDINO42');
-  });
-
-  it('Updates the token symbol', async () => {
-    const tx = await token.setSymbol('TREX42');
-    log(`[${calculateETH(tx.receipt.gasUsed)} ETH] --> fees of setSymbol transaction`);
-    const newTokenSymbol = await token.symbol();
-    newTokenSymbol.should.equal('TREX42');
   });
 
   it('Updates the token onchainID', async () => {


### PR DESCRIPTION
### Refactoring Token Contract

- Removed setSymbol from Token
- Removed setName from Token
- Removed tests on both functions
- Removed CallSetName from OwnerManager
- Removed CallSetSymbol from OwnerManager
- Added `Require `on empty strings making it impossible to set an empty `Name `or `Symbol `


It should be impossible to set an empty **Name** or **Symbol**, and it should be impossible to modify **Name** or **Symbol** as it could lead to _undefined behavior_ as previously encountered with **Etherscan**

We should consider removing **TokenOnchainID** from the constructor, as it is unnecessary to Add a **zeroAddress** and set it afterward, but like we said it could break many services like Graph