### PR TITLE
✨(identityRegistry) Compute array of claimIds from trusted issuers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [4.0.0]
+
+### Breaking changes
+
+### Update
+- Trusted Issuers Registry Storage now maintains a mapping of truster issuers addresses allowed for a given claim topic.
+  - This means adding/removing/updating a trusted issuer now cost more gas (especially removing and updating when removing topics).
+- Trusted Issuers Registry now implements a `getTrustedIssuersForClaimTopic(uint256 claimTopic)` method to query trusted issuers allowed for a given claim topic.
+- Identity Registry `isVerified` method now takes advantage of the new `getTrustedIssuersForClaimTopic`.
+  - Verifying an identity should now cost less gas, as the registry now only attempts to fetch claims that would be allowed.
+  - Identity can therefore no longer be blocked because it contains too many claims of a given topic.
+
+### Fix
+
 ## [3.5.1]
 
 ### Update 

--- a/contracts/registry/implementation/IdentityRegistry.sol
+++ b/contracts/registry/implementation/IdentityRegistry.sol
@@ -176,10 +176,17 @@ contract IdentityRegistry is IIdentityRegistry, AgentRoleUpgradeable, IRStorage 
         if (address(identity(_userAddress)) == address(0)) {
             return false;
         }
+
         uint256[] memory requiredClaimTopics = tokenTopicsRegistry.getClaimTopics();
         if (requiredClaimTopics.length == 0) {
             return true;
         }
+
+        IClaimIssuer[] memory trustedIssuers = tokenIssuersRegistry.getTrustedIssuers();
+        if (trustedIssuers.length == 0) {
+            return false;
+        }
+
         uint256 foundClaimTopic;
         uint256 scheme;
         address issuer;
@@ -187,36 +194,35 @@ contract IdentityRegistry is IIdentityRegistry, AgentRoleUpgradeable, IRStorage 
         bytes memory data;
         uint256 claimTopic;
         for (claimTopic = 0; claimTopic < requiredClaimTopics.length; claimTopic++) {
-            bytes32[] memory claimIds = identity(_userAddress).getClaimIdsByTopic(requiredClaimTopics[claimTopic]);
-            if (claimIds.length == 0) {
-                return false;
+            bytes32[] memory claimIds = new bytes32[](trustedIssuers.length);
+            for (uint256 i = 0; i < trustedIssuers.length; i++) {
+                claimIds[i] = keccak256(abi.encode(trustedIssuers[i], claimTopic));
             }
-            require(claimIds.length < 10, "too much claims of same topic");
+
             for (uint256 j = 0; j < claimIds.length; j++) {
                 (foundClaimTopic, scheme, issuer, sig, data, ) = identity(_userAddress).getClaim(claimIds[j]);
 
-                try IClaimIssuer(issuer).isClaimValid(identity(_userAddress), requiredClaimTopics[claimTopic], sig,
-                    data) returns(bool _validity){
-                    if (
-                        _validity
-                        && tokenIssuersRegistry.hasClaimTopic(issuer, requiredClaimTopics[claimTopic])
-                        && tokenIssuersRegistry.isTrustedIssuer(issuer)
-                    ) {
-                        j = claimIds.length;
+                if (foundClaimTopic == requiredClaimTopics[claimTopic]) {
+                    try IClaimIssuer(issuer).isClaimValid(identity(_userAddress), requiredClaimTopics[claimTopic], sig,
+                        data) returns(bool _validity){
+                        if (
+                            _validity
+                            && tokenIssuersRegistry.hasClaimTopic(issuer, requiredClaimTopics[claimTopic])
+                            && tokenIssuersRegistry.isTrustedIssuer(issuer)
+                        ) {
+                            j = claimIds.length;
+                        }
+                        if (!tokenIssuersRegistry.hasClaimTopic(issuer, requiredClaimTopics[claimTopic]) && j == (claimIds.length - 1)) {
+                            return false;
+                        }
+                        if (!_validity && j == (claimIds.length - 1)) {
+                            return false;
+                        }
                     }
-                    if (!tokenIssuersRegistry.isTrustedIssuer(issuer) && j == (claimIds.length - 1)) {
-                        return false;
-                    }
-                    if (!tokenIssuersRegistry.hasClaimTopic(issuer, requiredClaimTopics[claimTopic]) && j == (claimIds.length - 1)) {
-                        return false;
-                    }
-                    if (!_validity && j == (claimIds.length - 1)) {
-                        return false;
-                    }
-                }
-                catch {
-                    if (j == (claimIds.length - 1)) {
-                        return false;
+                    catch {
+                        if (j == (claimIds.length - 1)) {
+                            return false;
+                        }
                     }
                 }
             }

--- a/contracts/registry/implementation/IdentityRegistry.sol
+++ b/contracts/registry/implementation/IdentityRegistry.sol
@@ -225,6 +225,10 @@ contract IdentityRegistry is IIdentityRegistry, AgentRoleUpgradeable, IRStorage 
                         }
                     }
                 }
+
+                if (j == (claimIds.length - 1)) {
+                    return false;
+                }
             }
         }
         return true;

--- a/contracts/registry/interface/ITrustedIssuersRegistry.sol
+++ b/contracts/registry/interface/ITrustedIssuersRegistry.sol
@@ -129,6 +129,13 @@ interface ITrustedIssuersRegistry {
     function getTrustedIssuers() external view returns (IClaimIssuer[] memory);
 
     /**
+     *  @dev Function for getting all the trusted issuer allowed for a given claim topic.
+     *  @param claimTopic the claim topic to get the trusted issuers for.
+     *  @return array of all claim issuer addresses that are allowed for the given claim topic.
+     */
+    function getTrustedIssuersForClaimTopic(uint256 claimTopic) external view returns (IClaimIssuer[] memory);
+
+    /**
      *  @dev Checks if the ClaimIssuer contract is trusted
      *  @param _issuer the address of the ClaimIssuer contract
      *  @return true if the issuer is trusted, false otherwise.

--- a/contracts/registry/storage/TIRStorage.sol
+++ b/contracts/registry/storage/TIRStorage.sol
@@ -71,6 +71,9 @@ contract TIRStorage {
     /// @dev Mapping between a trusted issuer address and its corresponding claimTopics.
     mapping(address => uint256[]) internal trustedIssuerClaimTopics;
 
+    /// @dev Mapping between a claim topic and the allowed trusted issuers for it.
+    mapping(uint256 => IClaimIssuer[]) internal claimTopicsToTrustedIssuers;
+
     /**
      * @dev This empty reserved space is put in place to allow future versions to add new
      * variables without shifting down storage in the inheritance chain.


### PR DESCRIPTION
- This prevents from querying claims that would not be allowed because they were emitted from an untrusted issuer.
- This also prevents an Identity Owner to be unable to be verified because they might have too many claims of a given topic.


> **Note**
> Further optimization could be performed if the Trusted Issuer Registry had a method `getTrustedIssuersByClaimTopic(uint256 claimTopic)` (I might implement this on this PR).

- [x] modify `isVerified` function to check only claimIDs from trusted issuers
- [x] modify TrustedIssuersRegistry to store a mapping between claim topic and trusted issuers
- [x] add test cases for the modifications 
- [x] modify NatSpec for `isVerified`
- [x] add NatSpec for modifications on TIR 
- [x] update in changeLog 
- [x] (eventually) compare gas cost of new `isVerified` implem to old implem


Gas cost comparison for a transfer with and without this optimization (minor):

(comparing https://github.com/TokenySolutions/T-REX/actions/runs/3727061919/jobs/6320901174 and https://github.com/TokenySolutions/T-REX/actions/runs/3732257985/jobs/6331470948)

| Operation | With this PR | Without |
| *-------* | ------------ | ------- |
| Transfer  | 155742  | 191913 |
| Batch with 20 transfers | 2196700  | 2920120 |
