### PR TITLE
✅(registries) Add test to cover missing statements

### DIFF
--- a/contracts/registry/implementation/IdentityRegistry.sol
+++ b/contracts/registry/implementation/IdentityRegistry.sol
@@ -215,8 +215,7 @@ contract IdentityRegistry is IIdentityRegistry, AgentRoleUpgradeable, IRStorage 
                         if (!_validity && j == (claimIds.length - 1)) {
                             return false;
                         }
-                    }
-                    catch {
+                    } catch {
                         if (j == (claimIds.length - 1)) {
                             return false;
                         }

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -419,9 +419,23 @@ contract('IdentityRegistry', (accounts) => {
             await identity.addClaim(claimTopic, 1, trustedIssuer.address, '0x13', '0x10', '0x', { from: accounts[1] });
 
             expect(await identityRegistry.isVerified(identityOwner)).to.equal(false);
+
+            const [claimId] = await identity.getClaimIdsByTopic(claimTopic);
+            await identity.removeClaim(claimId, { from: accounts[1] });
           });
         },
       );
+
+      describe('When there is a claim topic expected and a trusted issuer, that is not a claim issuer contract, and the identity has a claim from it', () => {
+        it('Should return false', async () => {
+          const otherContract = await deployIdentityProxy(accounts[4]);
+          await identity.addClaim(claimTopic, 1, otherContract, '0x13', '0x10', '0x', { from: accounts[1] });
+          expect(await identityRegistry.isVerified(identityOwner)).to.equal(false);
+
+          const [claimId] = await identity.getClaimIdsByTopic(claimTopic);
+          await identity.removeClaim(claimId, { from: accounts[1] });
+        });
+      });
     });
   });
 });

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -429,7 +429,7 @@ contract('IdentityRegistry', (accounts) => {
       describe('When there is a claim topic expected and a trusted issuer, that is not a claim issuer contract, and the identity has a claim from it', () => {
         it('Should return false', async () => {
           const otherContract = await deployIdentityProxy(accounts[4]);
-          await identity.addClaim(claimTopic, 1, otherContract, '0x13', '0x10', '0x', { from: accounts[1] });
+          await identity.addClaim(claimTopic, 1, otherContract.address, '0x13', '0x10', '0x', { from: accounts[1] });
           expect(await identityRegistry.isVerified(identityOwner)).to.equal(false);
 
           const [claimId] = await identity.getClaimIdsByTopic(claimTopic);


### PR DESCRIPTION
Add tests to improve coverage.

- [x] Add test for `IdentityRegistry.isVerified` (statements that were not already covered by transfer tests).
- [x] Add tests for `IdentityRegistry.setIdentityRegistryStorage`.

We do have an issue with the try/catch that seems to not properly catch the error when the Trusted Issuer in the claim is not a Trusted Issuer contract (the `isVerified` returns a revert).