### PR TITLE
✨(modules) Add name to modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ All notable changes to this project will be documented in this file.
 - Implement a new compliance module `Supply Limit Module` that prevents minting more tokens that the specified limit.
 - Implement a new compliance module `Time Transfers limits` that prevents holders from transfering more token than a specified limit in a given time frame.
 - Implement two new compliance modules `Time Exchange limits` and `Monthly Exchange limits` that limit exchanges transfers. These are used to authorized specific trusted exchanges to hold tokens but limited to a certain amount transfered for a given time frame.
-- Add `string constant public NAME;` to `IModule`. Compliance modules now require a `string constant public NAME = "TimeTransfersLimitsModule";` constant variable to be declared.
+- Add `function name() external pure returns (string memory _name);` to `IModule`. Compliance modules now require a
+  `function name() public pure returns (string memory _name) {
+    return "CountryRestrictModule";
+  }`
+  constant variable to be declared.
 
 ## [4.0.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Implement a new compliance module `Supply Limit Module` that prevents minting more tokens that the specified limit.
 - Implement a new compliance module `Time Transfers limits` that prevents holders from transfering more token than a specified limit in a given time frame.
 - Implement two new compliance modules `Time Exchange limits` and `Monthly Exchange limits` that limit exchanges transfers. These are used to authorized specific trusted exchanges to hold tokens but limited to a certain amount transfered for a given time frame.
+- Add `function name() external pure returns (string memory);` to `IModule`. Compliance modules now require a `string constant public name = "ConditionalTransferModule";` constant variable to be declared.
 
 ## [4.0.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 - Implement a new compliance module `Supply Limit Module` that prevents minting more tokens that the specified limit.
 - Implement a new compliance module `Time Transfers limits` that prevents holders from transfering more token than a specified limit in a given time frame.
 - Implement two new compliance modules `Time Exchange limits` and `Monthly Exchange limits` that limit exchanges transfers. These are used to authorized specific trusted exchanges to hold tokens but limited to a certain amount transfered for a given time frame.
-- Add `function name() external pure returns (string memory);` to `IModule`. Compliance modules now require a `string constant public name = "ConditionalTransferModule";` constant variable to be declared.
+- Add `string constant public NAME;` to `IModule`. Compliance modules now require a `string constant public NAME = "TimeTransfersLimitsModule";` constant variable to be declared.
 
 ## [4.0.1]
 

--- a/contracts/compliance/modular/modules/ConditionalTransferModule.sol
+++ b/contracts/compliance/modular/modules/ConditionalTransferModule.sol
@@ -71,7 +71,7 @@ import "../../../roles/AgentRole.sol";
  *  this module allows to require the pre-validation of a transfer before allowing it to be executed
  */
 contract ConditionalTransferModule is AbstractModule {
-    string constant public name = "ConditionalTransferModule";
+    string public constant NAME = "ConditionalTransferModule";
 
     /// Mapping between transfer details and their approval status (amount of transfers approved) per compliance
     mapping(address => mapping(bytes32 => uint)) private _transfersApproved;

--- a/contracts/compliance/modular/modules/ConditionalTransferModule.sol
+++ b/contracts/compliance/modular/modules/ConditionalTransferModule.sol
@@ -250,6 +250,9 @@ contract ConditionalTransferModule is AbstractModule {
         return transferHash;
     }
 
+    /**
+     *  @dev See {IModule-name}.
+     */
     function name() public pure returns (string memory _name) {
         return "ConditionalTransferModule";
     }

--- a/contracts/compliance/modular/modules/ConditionalTransferModule.sol
+++ b/contracts/compliance/modular/modules/ConditionalTransferModule.sol
@@ -71,8 +71,6 @@ import "../../../roles/AgentRole.sol";
  *  this module allows to require the pre-validation of a transfer before allowing it to be executed
  */
 contract ConditionalTransferModule is AbstractModule {
-    string public constant NAME = "ConditionalTransferModule";
-
     /// Mapping between transfer details and their approval status (amount of transfers approved) per compliance
     mapping(address => mapping(bytes32 => uint)) private _transfersApproved;
 
@@ -250,5 +248,9 @@ contract ConditionalTransferModule is AbstractModule {
     ) public pure returns (bytes32){
         bytes32 transferHash = keccak256(abi.encode(_from, _to, _amount, _token));
         return transferHash;
+    }
+
+    function name() public pure returns (string memory _name) {
+        return "ConditionalTransferModule";
     }
 }

--- a/contracts/compliance/modular/modules/ConditionalTransferModule.sol
+++ b/contracts/compliance/modular/modules/ConditionalTransferModule.sol
@@ -71,6 +71,7 @@ import "../../../roles/AgentRole.sol";
  *  this module allows to require the pre-validation of a transfer before allowing it to be executed
  */
 contract ConditionalTransferModule is AbstractModule {
+    string constant public name = "ConditionalTransferModule";
 
     /// Mapping between transfer details and their approval status (amount of transfers approved) per compliance
     mapping(address => mapping(bytes32 => uint)) private _transfersApproved;

--- a/contracts/compliance/modular/modules/CountryAllowModule.sol
+++ b/contracts/compliance/modular/modules/CountryAllowModule.sol
@@ -194,6 +194,9 @@ contract CountryAllowModule is AbstractModule {
         return _allowedCountries[_compliance][_country];
     }
 
+    /**
+     *  @dev See {IModule-name}.
+     */
     function name() public pure returns (string memory _name) {
         return "CountryAllowModule";
     }

--- a/contracts/compliance/modular/modules/CountryAllowModule.sol
+++ b/contracts/compliance/modular/modules/CountryAllowModule.sol
@@ -67,8 +67,6 @@ import "../../../token/IToken.sol";
 import "./AbstractModule.sol";
 
 contract CountryAllowModule is AbstractModule {
-    string constant public NAME = "CountryAllowModule";
-
     /// Mapping between country and their allowance status per compliance contract
     mapping(address => mapping(uint16 => bool)) private _allowedCountries;
 
@@ -194,6 +192,10 @@ contract CountryAllowModule is AbstractModule {
      */
     function isCountryAllowed(address _compliance, uint16 _country) public view returns (bool) {
         return _allowedCountries[_compliance][_country];
+    }
+
+    function name() public pure returns (string memory _name) {
+        return "CountryAllowModule";
     }
 
     /**

--- a/contracts/compliance/modular/modules/CountryAllowModule.sol
+++ b/contracts/compliance/modular/modules/CountryAllowModule.sol
@@ -67,6 +67,7 @@ import "../../../token/IToken.sol";
 import "./AbstractModule.sol";
 
 contract CountryAllowModule is AbstractModule {
+    string constant public name = "CountryAllowModule";
 
     /// Mapping between country and their allowance status per compliance contract
     mapping(address => mapping(uint16 => bool)) private _allowedCountries;

--- a/contracts/compliance/modular/modules/CountryAllowModule.sol
+++ b/contracts/compliance/modular/modules/CountryAllowModule.sol
@@ -67,7 +67,7 @@ import "../../../token/IToken.sol";
 import "./AbstractModule.sol";
 
 contract CountryAllowModule is AbstractModule {
-    string constant public name = "CountryAllowModule";
+    string constant public NAME = "CountryAllowModule";
 
     /// Mapping between country and their allowance status per compliance contract
     mapping(address => mapping(uint16 => bool)) private _allowedCountries;

--- a/contracts/compliance/modular/modules/CountryRestrictModule.sol
+++ b/contracts/compliance/modular/modules/CountryRestrictModule.sol
@@ -67,6 +67,7 @@ import "../../../token/IToken.sol";
 import "./AbstractModule.sol";
 
 contract CountryRestrictModule is AbstractModule {
+    string constant public name = "CountryRestrictModule";
 
     /// Mapping between country and their restriction status per compliance contract
     mapping(address => mapping(uint16 => bool)) private _restrictedCountries;

--- a/contracts/compliance/modular/modules/CountryRestrictModule.sol
+++ b/contracts/compliance/modular/modules/CountryRestrictModule.sol
@@ -67,8 +67,6 @@ import "../../../token/IToken.sol";
 import "./AbstractModule.sol";
 
 contract CountryRestrictModule is AbstractModule {
-    string constant public NAME = "CountryRestrictModule";
-
     /// Mapping between country and their restriction status per compliance contract
     mapping(address => mapping(uint16 => bool)) private _restrictedCountries;
 
@@ -196,6 +194,10 @@ contract CountryRestrictModule is AbstractModule {
     function isCountryRestricted(address _compliance, uint16 _country) public view
     returns (bool) {
         return ((_restrictedCountries[_compliance])[_country]);
+    }
+
+    function name() public pure returns (string memory _name) {
+        return "CountryRestrictModule";
     }
 
     /**

--- a/contracts/compliance/modular/modules/CountryRestrictModule.sol
+++ b/contracts/compliance/modular/modules/CountryRestrictModule.sol
@@ -196,6 +196,9 @@ contract CountryRestrictModule is AbstractModule {
         return ((_restrictedCountries[_compliance])[_country]);
     }
 
+    /**
+     *  @dev See {IModule-name}.
+     */
     function name() public pure returns (string memory _name) {
         return "CountryRestrictModule";
     }

--- a/contracts/compliance/modular/modules/CountryRestrictModule.sol
+++ b/contracts/compliance/modular/modules/CountryRestrictModule.sol
@@ -67,7 +67,7 @@ import "../../../token/IToken.sol";
 import "./AbstractModule.sol";
 
 contract CountryRestrictModule is AbstractModule {
-    string constant public name = "CountryRestrictModule";
+    string constant public NAME = "CountryRestrictModule";
 
     /// Mapping between country and their restriction status per compliance contract
     mapping(address => mapping(uint16 => bool)) private _restrictedCountries;

--- a/contracts/compliance/modular/modules/ExchangeMonthlyLimitsModule.sol
+++ b/contracts/compliance/modular/modules/ExchangeMonthlyLimitsModule.sol
@@ -260,6 +260,9 @@ contract ExchangeMonthlyLimitsModule is AbstractModule, Ownable {
         return _exchangeMonthlyLimit[compliance][_exchangeID];
     }
 
+    /**
+     *  @dev See {IModule-name}.
+     */
     function name() public pure returns (string memory _name) {
         return "ExchangeMonthlyLimitsModule";
     }

--- a/contracts/compliance/modular/modules/ExchangeMonthlyLimitsModule.sol
+++ b/contracts/compliance/modular/modules/ExchangeMonthlyLimitsModule.sol
@@ -70,13 +70,13 @@ import "./AbstractModule.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 contract ExchangeMonthlyLimitsModule is AbstractModule, Ownable {
-    string constant public name = "ExchangeMonthlyLimitsModule";
-
     /// Struct of transfer Counters
     struct ExchangeTransferCounter {
         uint256 monthlyCount;
         uint256 monthlyTimer;
     }
+
+    string constant public NAME = "ExchangeMonthlyLimitsModule";
 
     /// Getter for Tokens monthlyLimit
     mapping(address => mapping(address => uint256)) private _exchangeMonthlyLimit;

--- a/contracts/compliance/modular/modules/ExchangeMonthlyLimitsModule.sol
+++ b/contracts/compliance/modular/modules/ExchangeMonthlyLimitsModule.sol
@@ -76,8 +76,6 @@ contract ExchangeMonthlyLimitsModule is AbstractModule, Ownable {
         uint256 monthlyTimer;
     }
 
-    string constant public NAME = "ExchangeMonthlyLimitsModule";
-
     /// Getter for Tokens monthlyLimit
     mapping(address => mapping(address => uint256)) private _exchangeMonthlyLimit;
 
@@ -260,6 +258,10 @@ contract ExchangeMonthlyLimitsModule is AbstractModule, Ownable {
     */
     function getExchangeMonthlyLimit(address compliance, address _exchangeID) public view returns (uint256) {
         return _exchangeMonthlyLimit[compliance][_exchangeID];
+    }
+
+    function name() public pure returns (string memory _name) {
+        return "ExchangeMonthlyLimitsModule";
     }
 
     /**

--- a/contracts/compliance/modular/modules/ExchangeMonthlyLimitsModule.sol
+++ b/contracts/compliance/modular/modules/ExchangeMonthlyLimitsModule.sol
@@ -70,6 +70,8 @@ import "./AbstractModule.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 contract ExchangeMonthlyLimitsModule is AbstractModule, Ownable {
+    string constant public name = "ExchangeMonthlyLimitsModule";
+
     /// Struct of transfer Counters
     struct ExchangeTransferCounter {
         uint256 monthlyCount;

--- a/contracts/compliance/modular/modules/IModule.sol
+++ b/contracts/compliance/modular/modules/IModule.sol
@@ -83,6 +83,11 @@ interface IModule {
     /// functions
 
     /**
+     *  @dev returns the name of the module.
+     */
+    function name() external pure returns (string memory);
+
+    /**
      *  @dev binds the module to a compliance contract
      *  once the module is bound, the compliance contract can interact with the module
      *  this function can be called ONLY by the compliance contract itself (_compliance), through the

--- a/contracts/compliance/modular/modules/IModule.sol
+++ b/contracts/compliance/modular/modules/IModule.sol
@@ -63,6 +63,7 @@
 pragma solidity 0.8.17;
 
 interface IModule {
+    string constant public NAME;
 
     /// events
 
@@ -81,11 +82,6 @@ interface IModule {
     event ComplianceUnbound(address indexed _compliance);
 
     /// functions
-
-    /**
-     *  @dev returns the name of the module.
-     */
-    function name() external pure returns (string memory);
 
     /**
      *  @dev binds the module to a compliance contract

--- a/contracts/compliance/modular/modules/IModule.sol
+++ b/contracts/compliance/modular/modules/IModule.sol
@@ -63,8 +63,6 @@
 pragma solidity 0.8.17;
 
 interface IModule {
-    string constant public NAME;
-
     /// events
 
     /**
@@ -155,4 +153,10 @@ interface IModule {
      *  @param _compliance address of the compliance contract
      */
     function isComplianceBound(address _compliance) external view returns (bool);
+
+    /**
+     *  @dev getter for the name of the module
+     *  @return _name the name of the module
+     */
+    function name() external pure returns (string memory _name);
 }

--- a/contracts/compliance/modular/modules/MaxBalanceModule.sol
+++ b/contracts/compliance/modular/modules/MaxBalanceModule.sol
@@ -200,6 +200,13 @@ contract MaxBalanceModule is AbstractModule {
     }
 
     /**
+     *  @dev See {IModule-name}.
+     */
+    function name() public pure returns (string memory _name) {
+        return "CountryRestrictModule";
+    }
+
+    /**
      *  @dev function used to get the country of a wallet address.
      *  @param _compliance the compliance contract address for which the country verification is required
      *  @param _userAddress the address of the wallet to be checked

--- a/contracts/compliance/modular/modules/SupplyLimitModule.sol
+++ b/contracts/compliance/modular/modules/SupplyLimitModule.sol
@@ -67,7 +67,7 @@ import "../../../token/IToken.sol";
 import "./AbstractModule.sol";
 
 contract SupplyLimitModule is AbstractModule {
-    string constant public name = "SupplyLimitModule";
+    string constant public NAME = "SupplyLimitModule";
 
     /// supply limits array
     mapping(address => uint256) private _supplyLimits;

--- a/contracts/compliance/modular/modules/SupplyLimitModule.sol
+++ b/contracts/compliance/modular/modules/SupplyLimitModule.sol
@@ -67,8 +67,6 @@ import "../../../token/IToken.sol";
 import "./AbstractModule.sol";
 
 contract SupplyLimitModule is AbstractModule {
-    string constant public NAME = "SupplyLimitModule";
-
     /// supply limits array
     mapping(address => uint256) private _supplyLimits;
 
@@ -134,5 +132,9 @@ contract SupplyLimitModule is AbstractModule {
     */
     function getSupplyLimit(address _compliance) external view returns (uint256) {
         return _supplyLimits[_compliance];
+    }
+
+    function name() public pure returns (string memory _name) {
+        return "SupplyLimitModule";
     }
 }

--- a/contracts/compliance/modular/modules/SupplyLimitModule.sol
+++ b/contracts/compliance/modular/modules/SupplyLimitModule.sol
@@ -67,6 +67,7 @@ import "../../../token/IToken.sol";
 import "./AbstractModule.sol";
 
 contract SupplyLimitModule is AbstractModule {
+    string constant public name = "SupplyLimitModule";
 
     /// supply limits array
     mapping(address => uint256) private _supplyLimits;

--- a/contracts/compliance/modular/modules/SupplyLimitModule.sol
+++ b/contracts/compliance/modular/modules/SupplyLimitModule.sol
@@ -134,6 +134,9 @@ contract SupplyLimitModule is AbstractModule {
         return _supplyLimits[_compliance];
     }
 
+    /**
+     *  @dev See {IModule-name}.
+     */
     function name() public pure returns (string memory _name) {
         return "SupplyLimitModule";
     }

--- a/contracts/compliance/modular/modules/TimeExchangeLimitsModule.sol
+++ b/contracts/compliance/modular/modules/TimeExchangeLimitsModule.sol
@@ -70,8 +70,6 @@ import "./AbstractModule.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 contract TimeExchangeLimitsModule is AbstractModule, Ownable {
-    string constant public name = "TimeExchangeLimitsModule";
-
     /// Struct of transfer Counters
     struct ExchangeTransferCounter {
         uint256 value;
@@ -87,6 +85,8 @@ contract TimeExchangeLimitsModule is AbstractModule, Ownable {
         bool attributedLimit;
         uint8 limitIndex;
     }
+
+    string constant public NAME = "TimeExchangeLimitsModule";
 
     // Mapping for limit time indexes
     mapping(address => mapping (address => mapping(uint32 => IndexLimit))) private _limitValues;

--- a/contracts/compliance/modular/modules/TimeExchangeLimitsModule.sol
+++ b/contracts/compliance/modular/modules/TimeExchangeLimitsModule.sol
@@ -70,6 +70,8 @@ import "./AbstractModule.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 contract TimeExchangeLimitsModule is AbstractModule, Ownable {
+    string constant public name = "TimeExchangeLimitsModule";
+
     /// Struct of transfer Counters
     struct ExchangeTransferCounter {
         uint256 value;

--- a/contracts/compliance/modular/modules/TimeExchangeLimitsModule.sol
+++ b/contracts/compliance/modular/modules/TimeExchangeLimitsModule.sol
@@ -280,6 +280,9 @@ contract TimeExchangeLimitsModule is AbstractModule, Ownable {
         return _exchangeIDs[_exchangeID];
     }
 
+    /**
+     *  @dev See {IModule-name}.
+     */
     function name() public pure returns (string memory _name) {
         return "TimeExchangeLimitsModule";
     }

--- a/contracts/compliance/modular/modules/TimeExchangeLimitsModule.sol
+++ b/contracts/compliance/modular/modules/TimeExchangeLimitsModule.sol
@@ -86,8 +86,6 @@ contract TimeExchangeLimitsModule is AbstractModule, Ownable {
         uint8 limitIndex;
     }
 
-    string constant public NAME = "TimeExchangeLimitsModule";
-
     // Mapping for limit time indexes
     mapping(address => mapping (address => mapping(uint32 => IndexLimit))) private _limitValues;
 
@@ -280,6 +278,10 @@ contract TimeExchangeLimitsModule is AbstractModule, Ownable {
     */
     function isExchangeID(address _exchangeID) public view returns (bool){
         return _exchangeIDs[_exchangeID];
+    }
+
+    function name() public pure returns (string memory _name) {
+        return "TimeExchangeLimitsModule";
     }
 
     /**

--- a/contracts/compliance/modular/modules/TimeTransfersLimitsModule.sol
+++ b/contracts/compliance/modular/modules/TimeTransfersLimitsModule.sol
@@ -67,8 +67,6 @@ import "../../../token/IToken.sol";
 import "./AbstractModule.sol";
 
 contract TimeTransfersLimitsModule is AbstractModule {
-    string constant public name = "TimeTransfersLimitsModule";
-
     /// Struct of transfer Counters
     struct TransferCounter {
         uint256 value;
@@ -84,6 +82,8 @@ contract TimeTransfersLimitsModule is AbstractModule {
         bool attributedLimit;
         uint8 limitIndex;
     }
+
+    string constant public NAME = "TimeTransfersLimitsModule";
 
     // Mapping for limit time indexes
     mapping(address => mapping(uint32 => IndexLimit)) public limitValues;

--- a/contracts/compliance/modular/modules/TimeTransfersLimitsModule.sol
+++ b/contracts/compliance/modular/modules/TimeTransfersLimitsModule.sol
@@ -67,6 +67,8 @@ import "../../../token/IToken.sol";
 import "./AbstractModule.sol";
 
 contract TimeTransfersLimitsModule is AbstractModule {
+    string constant public name = "TimeTransfersLimitsModule";
+
     /// Struct of transfer Counters
     struct TransferCounter {
         uint256 value;

--- a/contracts/compliance/modular/modules/TimeTransfersLimitsModule.sol
+++ b/contracts/compliance/modular/modules/TimeTransfersLimitsModule.sol
@@ -185,6 +185,9 @@ contract TimeTransfersLimitsModule is AbstractModule {
         return transferLimits[_compliance];
     }
 
+    /**
+     *  @dev See {IModule-name}.
+     */
     function name() public pure returns (string memory _name) {
         return "TimeTransfersLimitsModule";
     }

--- a/contracts/compliance/modular/modules/TimeTransfersLimitsModule.sol
+++ b/contracts/compliance/modular/modules/TimeTransfersLimitsModule.sol
@@ -83,8 +83,6 @@ contract TimeTransfersLimitsModule is AbstractModule {
         uint8 limitIndex;
     }
 
-    string constant public NAME = "TimeTransfersLimitsModule";
-
     // Mapping for limit time indexes
     mapping(address => mapping(uint32 => IndexLimit)) public limitValues;
 
@@ -185,6 +183,10 @@ contract TimeTransfersLimitsModule is AbstractModule {
     */
     function getTimeTransferLimits(address _compliance) external view returns (Limit[] memory limits) {
         return transferLimits[_compliance];
+    }
+
+    function name() public pure returns (string memory _name) {
+        return "TimeTransfersLimitsModule";
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@tokenysolutions/t-rex",
-      "version": "4.0.1",
+      "version": "4.1.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "devDependencies": {
         "@commitlint/cli": "^17.6.1",

--- a/test/compliances/module-conditional-transfer.test.ts
+++ b/test/compliances/module-conditional-transfer.test.ts
@@ -18,6 +18,16 @@ describe('ConditionalTransferModule', () => {
     return { ...context, suite: { ...context.suite, conditionalTransferModule, mockContract } };
   }
 
+  describe('.name()', () => {
+    it('should return the name of the module', async () => {
+      const {
+        suite: { conditionalTransferModule },
+      } = await loadFixture(deployComplianceWithConditionalTransferModule);
+
+      expect(await conditionalTransferModule.name()).to.be.equal('ConditionalTransferModule');
+    });
+  });
+
   describe('.batchApproveTransfers', () => {
     describe('when the sender is not the compliance', () => {
       it('should revert', async () => {

--- a/test/compliances/module-country-allow.test.ts
+++ b/test/compliances/module-country-allow.test.ts
@@ -14,6 +14,16 @@ describe('CountryAllowModule', () => {
     return { ...context, suite: { ...context.suite, countryAllowModule } };
   }
 
+  describe('.name()', () => {
+    it('should return the name of the module', async () => {
+      const {
+        suite: { countryAllowModule },
+      } = await loadFixture(deployComplianceWithCountryAllowModule);
+
+      expect(await countryAllowModule.name()).to.be.equal('CountryAllowModule');
+    });
+  });
+
   describe('.batchAllowCountries()', () => {
     describe('when calling not via the Compliance contract', () => {
       it('should revert', async () => {

--- a/test/compliances/module-country-restrict.test.ts
+++ b/test/compliances/module-country-restrict.test.ts
@@ -14,6 +14,16 @@ describe('CountryRestrictModule', () => {
     return { ...context, suite: { ...context.suite, countryRestrictModule } };
   }
 
+  describe('.name()', () => {
+    it('should return the name of the module', async () => {
+      const {
+        suite: { countryRestrictModule },
+      } = await loadFixture(deployComplianceWithCountryRestrictModule);
+
+      expect(await countryRestrictModule.name()).to.equal('CountryRestrictModule');
+    });
+  });
+
   describe('.addCountryRestriction()', () => {
     describe('when the sender is a random wallet', () => {
       it('should reverts', async () => {

--- a/test/compliances/module-exchange-monthly-limits.test.ts
+++ b/test/compliances/module-exchange-monthly-limits.test.ts
@@ -42,6 +42,14 @@ describe('Compliance Module: ExchangeMonthlyLimits', () => {
     expect(await context.contracts.compliance.isModuleBound(context.contracts.complianceModule.address)).to.be.true;
   });
 
+  describe('.name()', () => {
+    it('should return the name of the module', async () => {
+      const context = await loadFixture(deployExchangeMonthlyLimitsFixture);
+
+      expect(await context.contracts.complianceModule.name()).to.be.eq('ExchangeMonthlyLimitsModule');
+    });
+  });
+
   describe('.setExchangeMonthlyLimit', () => {
     describe('when calling directly', () => {
       it('should revert', async () => {

--- a/test/compliances/module-supply-limit.test.ts
+++ b/test/compliances/module-supply-limit.test.ts
@@ -42,6 +42,14 @@ describe('Compliance Module: SupplyLimit', () => {
     expect(await context.suite.compliance.isModuleBound(context.suite.complianceModule.address)).to.be.true;
   });
 
+  describe('.name()', () => {
+    it('should return the name of the module', async () => {
+      const context = await loadFixture(deploySupplyLimitFixture);
+
+      expect(await context.suite.complianceModule.name()).to.be.equal('SupplyLimitModule');
+    });
+  });
+
   describe('.setSupplyLimit', () => {
     describe('when calling directly', () => {
       it('should revert', async () => {

--- a/test/compliances/module-time-exchange-limits.test.ts
+++ b/test/compliances/module-time-exchange-limits.test.ts
@@ -42,6 +42,14 @@ describe('Compliance Module: TimeExchangeLimits', () => {
     expect(await context.contracts.compliance.isModuleBound(context.contracts.complianceModule.address)).to.be.true;
   });
 
+  describe('.name()', () => {
+    it('should return the name of the module', async () => {
+      const context = await loadFixture(deployTimeExchangeLimitsFixture);
+
+      expect(await context.contracts.complianceModule.name()).to.be.equal('TimeExchangeLimitsModule');
+    });
+  });
+
   describe('.setExchangeLimit', () => {
     describe('when calling directly', () => {
       it('should revert', async () => {

--- a/test/compliances/module-time-transfer-limits.test.ts
+++ b/test/compliances/module-time-transfer-limits.test.ts
@@ -42,6 +42,14 @@ describe('Compliance Module: TimeTransferLimits', () => {
     expect(await context.contracts.compliance.isModuleBound(context.contracts.complianceModule.address)).to.be.true;
   });
 
+  describe('.name()', () => {
+    it('should return the name of the module', async () => {
+      const context = await loadFixture(deployTimeTransferLimitsFixture);
+
+      expect(await context.contracts.complianceModule.name()).to.be.equal('TimeTransfersLimitsModule');
+    });
+  });
+
   describe('.setTimeTransferLimit', () => {
     describe('when calling directly', () => {
       it('should revert', async () => {


### PR DESCRIPTION
- Add `function name() external pure returns (string memory);` to IModule. Compliance modules now require a `string constant public name = "ConditionalTransferModule";` constant variable to be declared.