### PR TITLE
Remove _compliance parameter from setSupplyLimit function of the SupplyLimitModule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [4.1.2]
+- **Compliance Modules**:
+  - Remove `_compliance` parameter from the `setSupplyLimit` function of the `SupplyLimitModule`
+
 ## [4.1.1]
 
 No changes, republishing package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [4.1.2]
 - **Compliance Modules**:
-  - Removed `_compliance` parameter from the `setSupplyLimit` function of the `SupplyLimitModule`
+  - Removed `_compliance` parameter from `setSupplyLimit` function of the `SupplyLimitModule`
 
 ## [4.1.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [4.1.2]
 - **Compliance Modules**:
-  - Remove `_compliance` parameter from the `setSupplyLimit` function of the `SupplyLimitModule`
+  - Removed `_compliance` parameter from the `setSupplyLimit` function of the `SupplyLimitModule`
 
 ## [4.1.1]
 

--- a/contracts/compliance/modular/modules/SupplyLimitModule.sol
+++ b/contracts/compliance/modular/modules/SupplyLimitModule.sol
@@ -84,9 +84,9 @@ contract SupplyLimitModule is AbstractModule {
      *  Only the owner of the Compliance smart contract can call this function
      *  emits an `SupplyLimitSet` event
      */
-    function setSupplyLimit(address _compliance, uint256 _limit) external onlyComplianceCall {
-        _supplyLimits[_compliance] = _limit;
-        emit SupplyLimitSet(_compliance, _limit);
+    function setSupplyLimit(uint256 _limit) external onlyComplianceCall {
+        _supplyLimits[msg.sender] = _limit;
+        emit SupplyLimitSet(msg.sender, _limit);
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tokenysolutions/t-rex",
-  "version": "4.1.1",
+  "version": "4.1.2-beta1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tokenysolutions/t-rex",
-      "version": "4.1.0-beta5",
+      "version": "4.1.2-beta1",
       "license": "SEE LICENSE IN LICENSE.md",
       "devDependencies": {
         "@commitlint/cli": "^17.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenysolutions/t-rex",
-  "version": "4.1.1",
+  "version": "4.1.2-beta1",
   "description": "A fully compliant environment for the issuance and use of tokenized securities.",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenysolutions/t-rex",
-  "version": "4.1.2-beta1",
+  "version": "4.1.2",
   "description": "A fully compliant environment for the issuance and use of tokenized securities.",
   "main": "index.js",
   "directories": {

--- a/test/compliances/module-supply-limit.test.ts
+++ b/test/compliances/module-supply-limit.test.ts
@@ -69,9 +69,7 @@ describe('Compliance Module: SupplyLimit', () => {
       it('should revert', async () => {
         const context = await loadFixture(deploySupplyLimitFixture);
 
-        await expect(context.suite.complianceModule.setSupplyLimit(context.suite.compliance.address, 100)).to.revertedWith(
-          'only bound compliance can call',
-        );
+        await expect(context.suite.complianceModule.setSupplyLimit(100)).to.revertedWith('only bound compliance can call');
       });
     });
 
@@ -80,10 +78,7 @@ describe('Compliance Module: SupplyLimit', () => {
         const context = await loadFixture(deploySupplyLimitFixture);
 
         const tx = await context.suite.compliance.callModuleFunction(
-          new ethers.utils.Interface(['function setSupplyLimit(address _compliance, uint256 _limit)']).encodeFunctionData('setSupplyLimit', [
-            context.suite.compliance.address,
-            100,
-          ]),
+          new ethers.utils.Interface(['function setSupplyLimit(uint256 _limit)']).encodeFunctionData('setSupplyLimit', [100]),
           context.suite.complianceModule.address,
         );
 
@@ -97,10 +92,7 @@ describe('Compliance Module: SupplyLimit', () => {
       it('should return', async () => {
         const context = await loadFixture(deploySupplyLimitFixture);
         await context.suite.compliance.callModuleFunction(
-          new ethers.utils.Interface(['function setSupplyLimit(address _compliance, uint256 _limit)']).encodeFunctionData('setSupplyLimit', [
-            context.suite.compliance.address,
-            1600,
-          ]),
+          new ethers.utils.Interface(['function setSupplyLimit(uint256 _limit)']).encodeFunctionData('setSupplyLimit', [1600]),
           context.suite.complianceModule.address,
         );
         const supplyLimit = await context.suite.complianceModule.getSupplyLimit(context.suite.compliance.address);
@@ -118,10 +110,7 @@ describe('Compliance Module: SupplyLimit', () => {
         const from = zeroAddress;
 
         await context.suite.compliance.callModuleFunction(
-          new ethers.utils.Interface(['function setSupplyLimit(address _compliance, uint256 _limit)']).encodeFunctionData('setSupplyLimit', [
-            context.suite.compliance.address,
-            1600,
-          ]),
+          new ethers.utils.Interface(['function setSupplyLimit(uint256 _limit)']).encodeFunctionData('setSupplyLimit', [1600]),
           context.suite.complianceModule.address,
         );
 
@@ -137,10 +126,7 @@ describe('Compliance Module: SupplyLimit', () => {
         const from = zeroAddress;
 
         await context.suite.compliance.callModuleFunction(
-          new ethers.utils.Interface(['function setSupplyLimit(address _compliance, uint256 _limit)']).encodeFunctionData('setSupplyLimit', [
-            context.suite.compliance.address,
-            1600,
-          ]),
+          new ethers.utils.Interface(['function setSupplyLimit(uint256 _limit)']).encodeFunctionData('setSupplyLimit', [1600]),
           context.suite.complianceModule.address,
         );
 


### PR DESCRIPTION
- Removed `_compliance` parameter from `setSupplyLimit` function of the `SupplyLimitModule` as it would not be possible to initialize it when deploying trex-suite through the trex factory