### PR TITLE
Modify IA storage slot on proxies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [4.1.3]
+
+### Update
+
+- **AbstractProxy**: updated the storage slot for `TREXImplementationAuthority` from 
+  `0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7` to 
+  `0x821f3e4d3d679f19eacc940c87acf846ea6eae24a63058ea750304437a62aafc` to avoid issues with blockchain explorers 
+  confusing the proxy pattern of T-REX for an ERC-1822 proxy (old storage slot was the slot used by ERC-1822) which 
+  caused errors in displaying the right ABIs for proxies using this implementation.  
+
 ## [4.1.2]
 - **Compliance Modules**:
   - Removed `_compliance` parameter from `setSupplyLimit` function of the `SupplyLimitModule`

--- a/contracts/proxy/AbstractProxy.sol
+++ b/contracts/proxy/AbstractProxy.sol
@@ -93,18 +93,19 @@ abstract contract AbstractProxy is IProxy, Initializable {
         address implemAuth;
         // solhint-disable-next-line no-inline-assembly
         assembly {
-            implemAuth := sload(0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7)
+            implemAuth := sload(0x821f3e4d3d679f19eacc940c87acf846ea6eae24a63058ea750304437a62aafc)
         }
         return implemAuth;
     }
 
     /**
-     *  @dev store the implementationAuthority contract address using the ERC-1822 implementation slot in storage
+     *  @dev store the implementationAuthority contract address using the ERC-3643 implementation slot in storage
+     *  the slot storage is the result of `keccak256("ERC-3643.proxy.beacon")`
      */
     function _storeImplementationAuthority(address implementationAuthority) internal {
         // solhint-disable-next-line no-inline-assembly
         assembly {
-            sstore(0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7, implementationAuthority)
+            sstore(0x821f3e4d3d679f19eacc940c87acf846ea6eae24a63058ea750304437a62aafc, implementationAuthority)
         }
     }
 

--- a/contracts/token/TokenStorage.sol
+++ b/contracts/token/TokenStorage.sol
@@ -76,7 +76,7 @@ contract TokenStorage {
     string internal _tokenSymbol;
     uint8 internal _tokenDecimals;
     address internal _tokenOnchainID;
-    string internal constant _TOKEN_VERSION = "4.1.1";
+    string internal constant _TOKEN_VERSION = "4.1.3";
 
     /// @dev Variables of freeze and pause functions
     mapping(address => bool) internal _frozen;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenysolutions/t-rex",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "A fully compliant environment for the issuance and use of tokenized securities.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Proxies were using the storage slot from the ERC-1822 proxy pattern, but instead of using it to store direct implementation we used it to store the address of the Implementation Authority. 
The fact of using this storage slot created issues with the explorers such as polygonscan which believed we used ERC-1822 and displayed the ABI of the Implementation Authority instead of the ABI of the implementation contracts. 

This PR proposes a new storage slot `0x821f3e4d3d679f19eacc940c87acf846ea6eae24a63058ea750304437a62aafc` which is the result of `keccak256("ERC-3643.proxy.beacon")`