### PR TITLE
Proxify DvA manager and implement token freeze logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [4.1.5]
+
+### Update
+- DvA Transfer Manager contract proxified
+- The DvA manager contract freezes the tokens to be transferred instead of being a vault (so it must be a token agent)
+- Only the token owner (rather than agents) can call setApprovalCriteria, as it is part of the main token settings.
+- 
 ## [4.1.4]
 
 ### Added

--- a/contracts/DVA/DVATransferManager.sol
+++ b/contracts/DVA/DVATransferManager.sol
@@ -436,10 +436,10 @@ contract DVATransferManager is IDVATransferManager, Initializable, OwnableUpgrad
         return transfer;
     }
 
+    // solhint-disable-next-line no-empty-blocks
+    function _authorizeUpgrade(address /*newImplementation*/) internal view override virtual onlyOwner { }
+
     function _generateTransferSignatureHash(bytes32 transferID) internal pure returns (bytes32) {
         return keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", transferID));
     }
-
-    // solhint-disable-next-line no-empty-blocks
-    function _authorizeUpgrade(address /*newImplementation*/) internal override virtual onlyOwner { }
 }

--- a/contracts/DVA/DVATransferManagerProxy.sol
+++ b/contracts/DVA/DVATransferManagerProxy.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-3.0
+//
+//                                             :+#####%%%%%%%%%%%%%%+
+//                                         .-*@@@%+.:+%@@@@@%%#***%@@%=
+//                                     :=*%@@@#=.      :#@@%       *@@@%=
+//                       .-+*%@%*-.:+%@@@@@@+.     -*+:  .=#.       :%@@@%-
+//                   :=*@@@@%%@@@@@@@@@%@@@-   .=#@@@%@%=             =@@@@#.
+//             -=+#%@@%#*=:.  :%@@@@%.   -*@@#*@@@@@@@#=:-              *@@@@+
+//            =@@%=:.     :=:   *@@@@@%#-   =%*%@@@@#+-.        =+       :%@@@%-
+//           -@@%.     .+@@@     =+=-.         @@#-           +@@@%-       =@@@@%:
+//          :@@@.    .+@@#%:                   :    .=*=-::.-%@@@+*@@=       +@@@@#.
+//          %@@:    +@%%*                         =%@@@@@@@@@@@#.  .*@%-       +@@@@*.
+//         #@@=                                .+@@@@%:=*@@@@@-      :%@%:      .*@@@@+
+//        *@@*                                +@@@#-@@%-:%@@*          +@@#.      :%@@@@-
+//       -@@%           .:-=++*##%%%@@@@@@@@@@@@*. :@+.@@@%:            .#@@+       =@@@@#:
+//      .@@@*-+*#%%%@@@@@@@@@@@@@@@@%%#**@@%@@@.   *@=*@@#                :#@%=      .#@@@@#-
+//      -%@@@@@@@@@@@@@@@*+==-:-@@@=    *@# .#@*-=*@@@@%=                 -%@@@*       =@@@@@%-
+//         -+%@@@#.   %@%%=   -@@:+@: -@@*    *@@*-::                   -%@@%=.         .*@@@@@#
+//            *@@@*  +@* *@@##@@-  #@*@@+    -@@=          .         :+@@@#:           .-+@@@%+-
+//             +@@@%*@@:..=@@@@*   .@@@*   .#@#.       .=+-       .=%@@@*.         :+#@@@@*=:
+//              =@@@@%@@@@@@@@@@@@@@@@@@@@@@%-      :+#*.       :*@@@%=.       .=#@@@@%+:
+//               .%@@=                 .....    .=#@@+.       .#@@@*:       -*%@@@@%+.
+//                 +@@#+===---:::...         .=%@@*-         +@@@+.      -*@@@@@%+.
+//                  -@@@@@@@@@@@@@@@@@@@@@@%@@@@=          -@@@+      -#@@@@@#=.
+//                    ..:::---===+++***###%%%@@@#-       .#@@+     -*@@@@@#=.
+//                                           @@@@@@+.   +@@*.   .+@@@@@%=.
+//                                          -@@@@@=   =@@%:   -#@@@@%+.
+//                                          +@@@@@. =@@@=  .+@@@@@*:
+//                                          #@@@@#:%@@#. :*@@@@#-
+//                                          @@@@@%@@@= :#@@@@+.
+//                                         :@@@@@@@#.:#@@@%-
+//                                         +@@@@@@-.*@@@*:
+//                                         #@@@@#.=@@@+.
+//                                         @@@@+-%@%=
+//                                        :@@@#%@%=
+//                                        +@@@@%-
+//                                        :#%%=
+//
+/**
+ *     NOTICE
+ *
+ *     The T-REX software is licensed under a proprietary license or the GPL v.3.
+ *     If you choose to receive it under the GPL v.3 license, the following applies:
+ *     T-REX is a suite of smart contracts implementing the ERC-3643 standard and
+ *     developed by Tokeny to manage and transfer financial assets on EVM blockchains
+ *
+ *     Copyright (C) 2023, Tokeny sàrl.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+pragma solidity 0.8.17;
+
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+contract DVATransferManagerProxy is ERC1967Proxy {
+    // solhint-disable-next-line no-empty-blocks
+    constructor(address implementation, bytes memory _data) ERC1967Proxy(implementation, _data) { }
+}

--- a/contracts/DVA/IDVATransferManager.sol
+++ b/contracts/DVA/IDVATransferManager.sol
@@ -202,7 +202,7 @@ interface IDVATransferManager {
         bytes32 approvalCriteriaHash
     );
 
-    error OnlyTokenAgentCanCall(address _tokenAddress);
+    error OnlyTokenOwnerCanCall(address _tokenAddress);
 
     error OnlyTransferSenderCanCall(bytes32 _transferID);
 
@@ -210,7 +210,7 @@ interface IDVATransferManager {
 
     error RecipientIsNotVerified(address _tokenAddress, address _recipient);
 
-    error DVAManagerIsNotVerifiedForTheToken(address _tokenAddress);
+    error DVAManagerIsNotAnAgentOfTheToken(address _tokenAddress);
 
     error InvalidTransferID(bytes32 _transferID);
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ type ContractJSON = {
   bytecode: string;
   deployedBytecode: string;
   linkReferences: any;
-}
+};
 
 export namespace contracts {
   // Token
@@ -52,6 +52,8 @@ export namespace contracts {
   export const DVDTransferManager: ContractJSON;
   // DVA
   export const DVATransferManager: ContractJSON;
+
+  export const DVATransferManagerProxy: ContractJSON;
   // compliance
   export const MCStorage: ContractJSON;
   export const ModularCompliance: ContractJSON;

--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ const TREXGateway = require('./artifacts/contracts/factory/TREXGateway.sol/TREXG
 const DVDTransferManager = require('./artifacts/contracts/DVD/DVDTransferManager.sol/DVDTransferManager.json');
 // DVA
 const DVATransferManager = require('./artifacts/contracts/DVA/DVATransferManager.sol/DVATransferManager.json');
+const DVATransferManagerProxy = require('./artifacts/contracts/DVA/DVATransferManagerProxy.sol/DVATransferManagerProxy.json');
 const IDVATransferManager = require('./artifacts/contracts/DVA/IDVATransferManager.sol/IDVATransferManager.json');
 // compliance
 const IModularCompliance = require('./artifacts/contracts/compliance/modular/IModularCompliance.sol/IModularCompliance.json');
@@ -118,6 +119,7 @@ module.exports = {
     DVDTransferManager,
     // DVA
     DVATransferManager,
+    DVATransferManagerProxy,
     // compliance
     MCStorage,
     ModularCompliance,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenysolutions/t-rex",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "description": "A fully compliant environment for the issuance and use of tokenized securities.",
   "main": "index.js",
   "directories": {

--- a/test/dva.test.ts
+++ b/test/dva.test.ts
@@ -89,6 +89,27 @@ describe('DVATransferManager', () => {
     };
   }
 
+  describe('.initialize', () => {
+    describe('when the contract is not initialized before', () => {
+      it('should initialize', async () => {
+        const context = await loadFixture(deployFullSuiteWithTransferManager);
+
+        const implementation = await ethers.deployContract('DVATransferManager');
+        const transferManagerProxy = await ethers.deployContract('DVATransferManagerProxy', [implementation.address, '0x']);
+        const transferManager = await ethers.getContractAt('DVATransferManager', transferManagerProxy.address);
+        await expect(transferManager.connect(context.accounts.deployer).initialize()).to.eventually.be.fulfilled;
+        await expect(transferManager.owner()).to.eventually.be.eq(context.accounts.deployer.address);
+      });
+    });
+
+    describe('when the contract is already initialized', () => {
+      it('should revert', async () => {
+        const context = await loadFixture(deployFullSuiteWithTransferManager);
+        await expect(context.suite.transferManager.initialize()).to.eventually.be.rejectedWith('Initializable: contract is already initialized');
+      });
+    });
+  });
+
   describe('.setApprovalCriteria', () => {
     describe('when sender is not a token agent', () => {
       it('should revert', async () => {


### PR DESCRIPTION
- DvA Transfer Manager contract proxified
- The DvA manager contract freezes the tokens to be transferred instead of being a vault (so it must be a token agent) 
- Only the token owner (rather than agents) can call setApprovalCriteria, as it is part of the main token settings. 