### PR TITLE
Move IAFactory into the contracts namespace

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -43,6 +43,7 @@ export namespace contracts {
   export const TokenProxy: ContractJSON;
   export const TrustedIssuersRegistryProxy: ContractJSON;
   // proxy/authority
+  export const IAFactory: ContractJSON;
   export const TREXImplementationAuthority: ContractJSON;
   // factory
   export const TREXFactory: ContractJSON;
@@ -80,7 +81,6 @@ export namespace interfaces {
   export const IIdentityRegistryStorage: ContractJSON;
   export const ITrustedIssuersRegistry: ContractJSON;
   export const IProxy: ContractJSON;
-  export const IAFactory: ContractJSON;
   export const IIAFactory: ContractJSON;
   export const ITREXImplementationAuthority: ContractJSON;
   export const ITREXFactory: ContractJSON;

--- a/index.js
+++ b/index.js
@@ -110,6 +110,7 @@ module.exports = {
     TokenProxy,
     TrustedIssuersRegistryProxy,
     // proxy/authority
+    IAFactory,
     TREXImplementationAuthority,
     // factory
     TREXFactory,
@@ -145,7 +146,6 @@ module.exports = {
     IIdentityRegistryStorage,
     ITrustedIssuersRegistry,
     IProxy,
-    IAFactory,
     IIAFactory,
     ITREXImplementationAuthority,
     ITREXFactory,


### PR DESCRIPTION
IAFactory was wrongly categorized as an interface. This PR moves it into the contracts namespace.